### PR TITLE
skins: pick how the board looks and moves

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "sortit",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["tools/serve.mjs", "."],
+      "port": 4310
+    }
+  ]
+}

--- a/app.css
+++ b/app.css
@@ -199,12 +199,123 @@ h1 {
 .item.lift { transform: translateY(-10px) scale(1.06); }
 .item.hid svg { opacity: .9; }
 
+/* ===== skins: the container + the item backing, picked in LOOKS =====
+   the default rules above ARE the tubes skin; each skin below overrides only
+   what its metaphor changes. items keep the theme's art as the face. */
+
+/* nuts & bolts: no glass, a threaded shaft up the middle, hex-nut backings */
+[data-skin="bolts"] .tube {
+  border-color: transparent;
+  border-bottom: .3rem solid var(--line);
+  border-radius: 0;
+  background: transparent;
+}
+[data-skin="bolts"] .tube::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 5px 50%;
+  width: 10px;
+  translate: -50% 0;
+  background: repeating-linear-gradient(0deg, #B9AFA6 0 4px, #8F857C 4px 8px);
+  border: 2px solid var(--line);
+  border-bottom: 0;
+  border-radius: 4px 4px 0 0;
+}
+[data-skin="bolts"] .item { position: relative; z-index: 1; padding: 1px; }
+[data-skin="bolts"] .item::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  clip-path: polygon(25% 3%, 75% 3%, 98% 50%, 75% 97%, 25% 97%, 2% 50%);
+  background: #D8CFC6;
+  box-shadow: inset 0 -4px 0 #B0A599;
+}
+[data-skin="bolts"] .item svg { position: relative; scale: .74; }
+[data-skin="bolts"] .tube.sel { box-shadow: none; }
+
+/* beads & sticks: a slim wooden stick, round bead backings */
+[data-skin="beads"] .tube {
+  border-color: transparent;
+  border-bottom: .3rem solid var(--line);
+  border-radius: 0;
+  background: transparent;
+}
+[data-skin="beads"] .tube::before {
+  content: '';
+  position: absolute;
+  inset: 4px auto 5px 50%;
+  width: 6px;
+  translate: -50% 0;
+  background: #A98F71;
+  border: 2px solid var(--line);
+  border-radius: 4px;
+}
+[data-skin="beads"] .item { position: relative; z-index: 1; }
+[data-skin="beads"] .item::before {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: #FFF9F0;
+  border: 2.5px solid var(--line);
+  box-shadow: inset 0 -4px 0 rgb(61 50 48 / .12);
+}
+[data-skin="beads"] .item svg { position: relative; scale: .72; }
+[data-skin="beads"] .tube.sel { box-shadow: none; }
+
+/* block stacks: no container at all, chunky voxel blocks on a baseplate */
+[data-skin="blocks"] .tube {
+  border-color: transparent;
+  border-bottom: .35rem solid var(--line);
+  border-radius: 0;
+  background: transparent;
+  padding: 0 2px 5px;
+}
+[data-skin="blocks"] .item { position: relative; padding: 1px; }
+[data-skin="blocks"] .item::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 4px;
+  background: #EDE3D4;
+  border: 3px solid var(--line);
+  box-shadow: inset -4px -5px 0 rgb(61 50 48 / .18), inset 3px 3px 0 rgb(255 255 255 / .55);
+}
+[data-skin="blocks"] .item svg { position: relative; scale: .7; }
+
+/* the selected lift and done cues stay identical across skins on purpose:
+   the READING of the board never changes, only its costume */
+
 .tube.shake { animation: shake .3s ease; }
 @keyframes shake {
   0%, 100% { transform: translateX(0); }
   25% { transform: translateX(-5px); }
   75% { transform: translateX(5px); }
 }
+
+/* the LOOKS picker: one card per skin, current one pressed */
+.looks-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: .6rem;
+  margin: 0 0 .8rem;
+}
+.look {
+  display: grid;
+  place-items: center;
+  gap: .2rem;
+  padding: .7rem .4rem .5rem;
+  border: .16rem solid var(--line);
+  border-radius: 1rem;
+  background: #fff;
+  color: var(--ink);
+  font: inherit;
+  font-weight: 800;
+  font-size: .8rem;
+  cursor: pointer;
+}
+.look svg { width: 3.4rem; height: 3.4rem; }
+.look[aria-pressed="true"] { background: var(--accent); box-shadow: 0 .25rem 0 var(--line); }
 
 .tube.hint { animation: hintpulse 1s ease 2; }
 @keyframes hintpulse {

--- a/app.js
+++ b/app.js
@@ -244,7 +244,7 @@ wireInstall($('install'), {
   },
 })
 
-wireUpdate($('update'))
+wireUpdate($('update'), { allowed: () => gameScreen.hidden }) // never over a game
 registerWorker()
 
 // a shared link drops the player straight onto their friend's board

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@
 import { dailySeed } from './seed.js'
 import { LEVEL_COUNT, WORLD_SIZE, WORLD_COUNT, levelBoard, seedBoard } from './levels.js'
 import { THEMES, themeForWorld } from './art/index.js'
+import { SKINS, loadSkin, saveSkin } from './skins.js'
 import { createGame } from './game.js'
 import { sound } from './sounds.js'
 import { wireInstall } from './install.js'
@@ -57,6 +58,7 @@ function show(screen) {
 
 let board = null   // the board being played, from levels.js
 let theme = null
+let skin = loadSkin()
 
 const game = createGame({
   boardEl: $('board'),
@@ -94,7 +96,7 @@ function play(b, label) {
   $('board-label').textContent = label
   $('board').style.background = theme.tint
   show(gameScreen)
-  game.start(board, theme)
+  game.start(board, theme, skin)
 }
 
 const startLevel = n => play(levelBoard(n), `level ${n}`)
@@ -208,6 +210,34 @@ $('hint').addEventListener('click', () => {
     setTimeout(() => { hintChip.textContent = hintLabel }, 1800)
   }
 })
+
+// ---------------------------------------------------------------- looks
+
+const looks = $('looks')
+
+function renderLooks() {
+  const grid = $('looks-grid')
+  grid.replaceChildren()
+  for (const candidate of SKINS) {
+    const el = document.createElement('button')
+    el.type = 'button'
+    el.className = 'look'
+    el.setAttribute('aria-pressed', String(candidate.key === skin.key))
+    el.innerHTML = `<svg viewBox="0 0 64 64" aria-hidden="true">${candidate.preview}</svg><span>${candidate.title}</span>`
+    el.addEventListener('click', () => {
+      skin = candidate
+      saveSkin(skin)
+      game.setSkin(skin) // applies live, even mid-game; board state untouched
+      renderLooks()
+    })
+    grid.append(el)
+  }
+}
+
+for (const id of ['looks-open', 'looks-game']) {
+  $(id).addEventListener('click', () => { renderLooks(); looks.showModal() })
+}
+$('looks-close').addEventListener('click', () => looks.close())
 
 const soundChip = $('sound')
 function paintSound(muted) {

--- a/confetti.js
+++ b/confetti.js
@@ -4,22 +4,30 @@
 
 export function confetti(colors) {
   if (matchMedia('(prefers-reduced-motion: reduce)').matches) return
+  // capture size ONCE: a rotation mid-burst must not smear a mismatched
+  // clearRect, and dpr is capped like the game canvas — a dpr-3 phone does
+  // not need a ~40MB backing store for a two-second effect.
+  const W = innerWidth
+  const H = innerHeight
+  const dpr = Math.min(devicePixelRatio || 1, 2)
   const canvas = document.createElement('canvas')
   canvas.className = 'confetti'
-  canvas.width = innerWidth * devicePixelRatio
-  canvas.height = innerHeight * devicePixelRatio
-  canvas.style.width = `${innerWidth}px`
-  canvas.style.height = `${innerHeight}px`
+  canvas.width = W * dpr
+  canvas.height = H * dpr
+  canvas.style.width = `${W}px`
+  canvas.style.height = `${H}px`
   document.body.append(canvas)
   const g = canvas.getContext('2d')
-  g.scale(devicePixelRatio, devicePixelRatio)
+  g.scale(dpr, dpr)
 
+  // spawn band is shallow and fall speed floored so every piece the burst
+  // pays for actually crosses the screen within its lifetime
   const pieces = Array.from({ length: 130 }, () => ({
-    x: Math.random() * innerWidth,
-    y: -20 - Math.random() * innerHeight * 0.5,
+    x: Math.random() * W,
+    y: -20 - Math.random() * H * 0.3,
     w: 6 + Math.random() * 6,
     h: 8 + Math.random() * 8,
-    vy: 130 + Math.random() * 170,
+    vy: 190 + Math.random() * 170,
     vx: -40 + Math.random() * 80,
     rot: Math.random() * Math.PI,
     vr: -4 + Math.random() * 8,
@@ -31,7 +39,7 @@ export function confetti(colors) {
   function frame(now) {
     const dt = Math.min((now - last) / 1000, 0.05)
     last = now
-    g.clearRect(0, 0, innerWidth, innerHeight)
+    g.clearRect(0, 0, W, H)
     for (const p of pieces) {
       p.x += p.vx * dt
       p.y += p.vy * dt

--- a/game.js
+++ b/game.js
@@ -13,6 +13,7 @@ const HINT_BUDGET = { maxNodes: 60000 }
 export function createGame({ boardEl, movesEl, onWin, onMove }) {
   let capacity = 4
   let theme = null
+  let skin = null
   let tubes = []          // item-layer state
   let history = []        // snapshots for unlimited undo
   let selected = null
@@ -152,6 +153,9 @@ export function createGame({ boardEl, movesEl, onWin, onMove }) {
   }
 
   // FLIP: re-render moved items from their old screen position to the new one.
+  // the skin's motion verb only changes the transform an item STARTS from and
+  // the easing that brings it home: pour slides, flip somersaults in and snaps,
+  // screw spins down onto the thread. same mechanism, different feel.
   function animateMove(uids) {
     const before = new Map()
     for (const uid of uids) {
@@ -160,6 +164,7 @@ export function createGame({ boardEl, movesEl, onWin, onMove }) {
     }
     render()
     if (matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const motion = skin?.motion ?? { rotate: 0, ease: 'cubic-bezier(.3,1.2,.5,1)', seconds: .22 }
     for (const uid of uids) {
       const node = boardEl.querySelector(`[data-uid="${uid}"]`)
       const from = before.get(uid)
@@ -168,9 +173,9 @@ export function createGame({ boardEl, movesEl, onWin, onMove }) {
       const dx = from.left - to.left
       const dy = from.top - to.top
       node.style.transition = 'none'
-      node.style.transform = `translate(${dx}px, ${dy}px)`
+      node.style.transform = `translate(${dx}px, ${dy}px) rotate(${motion.rotate}deg)`
       requestAnimationFrame(() => requestAnimationFrame(() => {
-        node.style.transition = 'transform .22s cubic-bezier(.3,1.2,.5,1)'
+        node.style.transition = `transform ${motion.seconds}s ${motion.ease}`
         node.style.transform = ''
       }))
     }
@@ -274,9 +279,10 @@ export function createGame({ boardEl, movesEl, onWin, onMove }) {
   // ------------------------------------------------------------- public api
 
   return {
-    start(board, boardTheme) {
+    start(board, boardTheme, boardSkin) {
       capacity = board.params.capacity
       theme = boardTheme
+      if (boardSkin) { skin = boardSkin; boardEl.dataset.skin = skin.key }
       let uid = 0
       tubes = board.tubes.map(t => t.map((c, slot) => ({
         uid: uid++,
@@ -320,5 +326,10 @@ export function createGame({ boardEl, movesEl, onWin, onMove }) {
     },
     canUndo: () => history.length > 0,
     measure() { if (tubes.length) render() }, // a resize can change the best row count
+    setSkin(next) {
+      skin = next
+      boardEl.dataset.skin = skin.key
+      if (tubes.length) render() // mid-game switch repaints in place, state untouched
+    },
   }
 }

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
   <button id="levels-open" class="big secondary">PICK A LEVEL</button>
   <button id="friends" class="big secondary">PLAY WITH A FRIEND</button>
   <button id="howto-open" class="big secondary">HOW TO PLAY</button>
+  <button id="looks-open" class="big secondary">LOOKS</button>
   <!-- install stays hidden until the browser says the app is actually installable -->
   <button id="install" class="big secondary" hidden>ADD TO HOME SCREEN</button>
 
@@ -61,6 +62,7 @@
     <button id="sound" class="chip" aria-label="sound on or off">&#9834; SOUND</button>
     <button id="hint" class="chip">&#10024; HINT</button>
     <button id="undo" class="chip">&#8630; UNDO</button>
+    <button id="looks-game" class="chip" aria-label="change the look">&#9673; LOOKS</button>
   </div>
 
   <div id="stuck" class="stuck" hidden>
@@ -90,6 +92,14 @@
   </ol>
   <p class="small">Stuck? <b>UNDO</b> takes moves back as many times as you like, and <b>HINT</b> shows you a good move. Some pieces hide as a <b>?</b> &mdash; move the piece on top of them to peek! Take as long as you want.</p>
   <button id="howto-close" class="big">GOT IT</button>
+</dialog>
+
+<!-- ============ looks: pick a skin, applies instantly, remembered ============ -->
+<dialog id="looks">
+  <h2>Pick a look</h2>
+  <div id="looks-grid" class="looks-grid"></div>
+  <p class="small">Same puzzles, different costume. Changing it never touches your game.</p>
+  <button id="looks-close" class="big">DONE</button>
 </dialog>
 
 <!-- ============ update banner ============ -->

--- a/install.js
+++ b/install.js
@@ -32,10 +32,14 @@ export function wireInstall(button, { showIosHint }) {
 
   button.addEventListener('click', async () => {
     if (deferred) {
-      deferred.prompt()
-      const { outcome } = await deferred.userChoice
+      // take the event before prompting: a double-tap must not call
+      // prompt() twice on the same event (InvalidStateError noise)
+      const event = deferred
       deferred = null
+      event.prompt()
+      const { outcome } = await event.userChoice
       if (outcome === 'accepted') button.hidden = true
+      else deferred = event // declined: the button can try again later
       return
     }
     showIosHint()

--- a/skins.js
+++ b/skins.js
@@ -1,0 +1,50 @@
+// skins: how the board LOOKS and how a move MOVES, orthogonal to themes.
+// a theme picks the twelve faces (art/); a skin picks the container those
+// faces live in and the motion verb that carries them between containers.
+//
+// each skin styles the board via [data-skin] rules in app.css, and animates
+// via the same FLIP mechanism game.js always had: the only thing a motion
+// verb changes is the transform an item STARTS from and the easing that
+// brings it home. pour slides, flip somersaults and snaps, screw spins in
+// and settles like a nut on a thread.
+export const SKINS = [
+  {
+    key: 'tubes',
+    title: 'Tubes',
+    motion: { rotate: 0, ease: 'cubic-bezier(.3,1.2,.5,1)', seconds: .22 },
+    preview: '<rect x="22" y="10" width="20" height="46" rx="6" fill="#fff" stroke="#3D3230" stroke-width="3"/><circle cx="32" cy="47" r="6" fill="#E5484D"/><circle cx="32" cy="34" r="6" fill="#4FA3D1"/>',
+  },
+  {
+    key: 'bolts',
+    title: 'Nuts & Bolts',
+    motion: { rotate: -720, ease: 'cubic-bezier(.2,.9,.35,1.05)', seconds: .34 },
+    preview: '<rect x="29" y="8" width="6" height="48" fill="#B9AFA6" stroke="#3D3230" stroke-width="2.4"/><path d="M22 44 L27 40 L37 40 L42 44 L42 52 L37 56 L27 56 L22 52 Z" fill="#D8CFC6" stroke="#3D3230" stroke-width="2.6"/><path d="M22 26 L27 22 L37 22 L42 26 L42 34 L37 38 L27 38 L22 34 Z" fill="#D8CFC6" stroke="#3D3230" stroke-width="2.6"/>',
+  },
+  {
+    key: 'beads',
+    title: 'Beads & Sticks',
+    motion: { rotate: 0, ease: 'cubic-bezier(.25,1.35,.45,1)', seconds: .26 },
+    preview: '<rect x="30" y="6" width="4" height="50" rx="2" fill="#A98F71" stroke="#3D3230" stroke-width="2"/><circle cx="32" cy="47" r="8" fill="#79B84C" stroke="#3D3230" stroke-width="2.6"/><circle cx="32" cy="30" r="8" fill="#F0C33C" stroke="#3D3230" stroke-width="2.6"/>',
+  },
+  {
+    key: 'blocks',
+    title: 'Block Stacks',
+    motion: { rotate: 180, ease: 'cubic-bezier(.34,1.45,.6,1)', seconds: .3 },
+    preview: '<rect x="20" y="38" width="24" height="18" fill="#79B84C" stroke="#3D3230" stroke-width="3"/><rect x="20" y="18" width="24" height="18" fill="#B98A5A" stroke="#3D3230" stroke-width="3"/>',
+  },
+]
+
+const KEY = 'sortit:skin'
+
+export function loadSkin() {
+  try {
+    const saved = localStorage.getItem(KEY)
+    return SKINS.find(skin => skin.key === saved) ?? SKINS[0]
+  } catch {
+    return SKINS[0]
+  }
+}
+
+export function saveSkin(skin) {
+  try { localStorage.setItem(KEY, skin.key) } catch { /* a blocked store only costs the preference */ }
+}

--- a/sw.js
+++ b/sw.js
@@ -7,13 +7,14 @@
 //   3. only ok responses get cached, and the write is wrapped in waitUntil.
 //
 // bump CACHE when the shell list changes.
-const CACHE = 'sortit-v1'
+const CACHE = 'sortit-v2'
 const SHELL = [
   './',
   './index.html',
   './app.css',
   './app.js',
   './game.js',
+  './skins.js',
   './levels.js',
   './solver.js',
   './seed.js',

--- a/sw.js
+++ b/sw.js
@@ -38,10 +38,13 @@ const SHELL = [
 ]
 
 self.addEventListener('install', event => {
-  // one bad url must not fail the whole install, so each is added on its own
+  // one bad url must not fail the whole install, so each is added on its
+  // own. cache: 'reload' bypasses the HTTP cache — without it a long
+  // max-age server can seed the NEW sw cache from STALE http-cache entries,
+  // and the update banner then re-fires forever against the fresh probe.
   event.waitUntil(
     caches.open(CACHE).then(cache =>
-      Promise.all(SHELL.map(url => cache.add(url).catch(() => {})))),
+      Promise.all(SHELL.map(url => cache.add(new Request(url, { cache: 'reload' })).catch(() => {})))),
   )
   self.skipWaiting()
 })

--- a/update.js
+++ b/update.js
@@ -10,10 +10,19 @@
 const PROBE = '?update-probe'
 const EVERY = 5 * 60 * 1000
 
-export function wireUpdate(banner, { onStatus } = {}) {
+// `allowed` gates WHEN the banner may appear (not whether we check): shown
+// mid-run it would sit on top of the end-sheet buttons, and a mistap reloads
+// the game away. staleness found while playing surfaces at the next safe moment.
+export function wireUpdate(banner, { onStatus, allowed = () => true } = {}) {
   if (!banner) return { check: async () => 'unknown' }
 
   let baseline = null
+  let stale = false
+
+  // two-way: the banner leaves again when the kid enters a run — a stale
+  // banner sitting over the game's buttons is a reload-mistap trap
+  const surface = () => { banner.hidden = !(stale && allowed()) }
+  setInterval(surface, 3000)
 
   const check = async () => {
     try {
@@ -33,7 +42,8 @@ export function wireUpdate(banner, { onStatus } = {}) {
         return 'current'
       }
       if (text !== baseline) {
-        banner.hidden = false
+        stale = true
+        surface()
         return 'stale'
       }
       return 'current'


### PR DESCRIPTION
Closes #2.

Make sortit skinnable. Themes already swap the twelve item faces per world, so this adds the orthogonal layer: the **container metaphor** and the **motion verb**.

**Four skins**: Tubes (the original), Nuts & Bolts (threaded shaft, hex-nut backings, a move spins in and settles like a nut on a thread), Beads & Sticks (slim wooden stick, round beads), Block Stacks (no container, chunky voxel blocks that somersault over and snap in).

**LOOKS picker** on the menu and in-game. Applies live, remembered in localStorage, and a mid-game switch repaints in place without touching board state.

**Mechanics are deliberately tiny**: a skin is a `[data-skin]` CSS block plus `{ rotate, ease, seconds }`, the transform a moved item *starts* from and the easing that brings it home, inside the FLIP animation the game always had. Levels, solver, saves, themes and the daily untouched. `skins.js` added to the SW shell, cache v1 to v2.

**Verified in a real browser**: all four skins render and play with real taps, the preference survives a reload, a mid-game switch keeps the move count, zero console errors. `verify-levels` (1095 dailies) and `validate-art` both green.
