### PR TITLE
board chrome: done-halo, in-game reset, clock, sound to menu

### DIFF
--- a/app.css
+++ b/app.css
@@ -168,22 +168,13 @@ h1 {
 .tube.sel { transform: translateY(-4px); box-shadow: 0 .35rem 0 var(--line); }
 .tube.done { border-color: #46A758; background: rgb(198 232 194 / .55); }
 
-/* the finished-tube badge is a FORM cue, not just the green tint */
+/* the finished cue is a HALO around the whole pillar: it works at any board
+   width (the old corner badge clipped off-screen on wide boards), it reads on
+   every skin, and brightness is a form cue a colourblind kid still gets */
 .tube { position: relative; }
-.tube.done::after {
-  content: '\2713';
-  position: absolute;
-  top: -.7rem;
-  right: -.4rem;
-  display: grid;
-  place-items: center;
-  width: 1.35rem;
-  height: 1.35rem;
-  border: .12rem solid var(--line);
-  border-radius: 50%;
-  background: #C6E8C2;
-  font-size: .8rem;
-  font-weight: 800;
+.tube.done {
+  box-shadow: 0 0 0 3px #46A758, 0 0 16px 4px rgb(70 167 88 / .55);
+  border-radius: .6rem;
 }
 
 .item {

--- a/app.js
+++ b/app.js
@@ -75,15 +75,17 @@ const game = createGame({
   movesEl: $('moves'),
   onMove: kind => { $('stuck').hidden = kind !== 'stuck' },
   onWin: moves => {
+    clockStopped = Date.now()
+    $('clock').textContent = clockText()
     const stars = starsFor(moves, board.par, board.solution.length)
-    let detail = `sorted in ${moves} moves!`
+    let detail = `sorted in ${moves} moves, ${clockText()}!`
     if (board.kind === 'level') {
       const best = progress.done[board.n]
       if (best == null || moves < best) {
         progress.done[board.n] = moves
-        if (best != null) detail = `sorted in ${moves} moves, your best yet!`
+        if (best != null) detail = `sorted in ${moves} moves, ${clockText()}, your best yet!`
       } else {
-        detail = `sorted in ${moves} moves. your best is ${best}.`
+        detail = `sorted in ${moves} moves, ${clockText()}. your best is ${best}.`
       }
       if (stars > (progress.stars[board.n] ?? 0)) progress.stars[board.n] = stars
       if (board.n === progress.current && progress.current < LEVEL_COUNT) progress.current += 1
@@ -111,10 +113,26 @@ function themeForBoard(b) {
   return THEMES[b.seed % THEMES.length]
 }
 
+// the clock: elapsed, not a countdown. it starts with the board, freezes on
+// the win, and never pressures anyone: the ethos "no timers" bans deadlines,
+// not a stopwatch a kid can brag with.
+let clockStart = null
+let clockStopped = null
+const clockText = () => {
+  const seconds = Math.floor(((clockStopped ?? Date.now()) - clockStart) / 1000)
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, '0')}`
+}
+setInterval(() => {
+  if (clockStart != null && clockStopped == null && !gameScreen.hidden) $('clock').textContent = clockText()
+}, 500)
+
 function play(b, label) {
   board = b
   theme = themeForBoard(b)
   board.par = null
+  clockStart = Date.now()
+  clockStopped = null
+  $('clock').textContent = '0:00'
   $('board-label').textContent = label
   $('board').style.background = theme.tint
   show(gameScreen)
@@ -229,6 +247,7 @@ $('share-win').addEventListener('click', event => share(event.currentTarget, boa
 const undo = () => { if (game.undo()) { $('stuck').hidden = true; $('won').hidden = true } }
 $('undo').addEventListener('click', undo)
 $('stuck-undo').addEventListener('click', undo)
+$('reset').addEventListener('click', () => replay()) // fresh board, fresh clock
 $('stuck-restart').addEventListener('click', () => { replay() })
 const hintChip = $('hint')
 const hintLabel = hintChip.textContent
@@ -262,9 +281,7 @@ function renderLooks() {
   }
 }
 
-for (const id of ['looks-open', 'looks-game']) {
-  $(id).addEventListener('click', () => { renderLooks(); looks.showModal() })
-}
+$('looks-open').addEventListener('click', () => { renderLooks(); looks.showModal() })
 $('looks-close').addEventListener('click', () => looks.close())
 
 const soundChip = $('sound')

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <button id="friends" class="big secondary">PLAY WITH A FRIEND</button>
   <button id="howto-open" class="big secondary">HOW TO PLAY</button>
   <button id="looks-open" class="big secondary">LOOKS</button>
+  <button id="sound" class="big secondary" aria-label="sound on or off">&#9834; SOUND</button>
   <!-- install stays hidden until the browser says the app is actually installable -->
   <button id="install" class="big secondary" hidden>ADD TO HOME SCREEN</button>
 
@@ -53,16 +54,16 @@
   <header class="bar">
     <button id="back" class="chip" aria-label="back to menu">&larr;</button>
     <span id="board-label" class="chip flat"></span>
+    <span id="clock" class="chip flat mono" aria-label="time elapsed">0:00</span>
     <span id="moves" class="chip flat mono" aria-live="polite">0 moves</span>
   </header>
 
   <div id="board" aria-label="sorting board"></div>
 
   <div class="actions">
-    <button id="sound" class="chip" aria-label="sound on or off">&#9834; SOUND</button>
     <button id="hint" class="chip">&#10024; HINT</button>
     <button id="undo" class="chip">&#8630; UNDO</button>
-    <button id="looks-game" class="chip" aria-label="change the look">&#9673; LOOKS</button>
+    <button id="reset" class="chip">&#8635; RESET</button>
   </div>
 
   <div id="stuck" class="stuck" hidden>

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   3. only ok responses get cached, and the write is wrapped in waitUntil.
 //
 // bump CACHE when the shell list changes.
-const CACHE = 'sortit-v3'
+const CACHE = 'sortit-v4'
 const SHELL = [
   './',
   './index.html',


### PR DESCRIPTION
Closes #6. Playtest feedback, all four items.

Verified in a real browser: menu carries LOOKS + SOUND, in-game row is HINT/UNDO/RESET, clock ticks 0:00 to 0:01 and freezes into the win text, reset returns moves and clock to zero, the done cue is a box-shadow halo with the ::after badge gone and the finished tube fully inside the viewport. verify-levels green. Zero console errors.
