### PR TITLE
three tribute skins: voxel mine, neon dash, kawaii pop

### DIFF
--- a/app.css
+++ b/app.css
@@ -274,6 +274,69 @@ h1 {
 }
 [data-skin="blocks"] .item svg { position: relative; scale: .7; }
 
+/* voxel mine: earthy dirt blocks with a grass cap, an aesthetic tribute */
+[data-skin="voxel"] .tube {
+  border-color: transparent;
+  border-bottom: .35rem solid var(--line);
+  border-radius: 0;
+  background: transparent;
+  padding: 0 2px 5px;
+}
+[data-skin="voxel"] .item { position: relative; padding: 1px; }
+[data-skin="voxel"] .item::before {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border: 3px solid var(--line);
+  background:
+    linear-gradient(0deg, transparent 78%, #6FA644 78%),
+    repeating-linear-gradient(45deg, #8A6142 0 6px, #7A5238 6px 12px);
+  box-shadow: inset -4px -5px 0 rgb(0 0 0 / .22), inset 3px 3px 0 rgb(255 255 255 / .18);
+  image-rendering: pixelated;
+}
+[data-skin="voxel"] .item svg { position: relative; scale: .66; }
+
+/* neon dash: dark grid, glowing cube outlines, an aesthetic tribute */
+[data-skin="dash"] { background: #141A2E !important; }
+[data-skin="dash"] .tube {
+  border-color: rgb(62 240 208 / .5);
+  border-bottom: .3rem solid #3EF0D0;
+  border-radius: 0 0 .5rem .5rem;
+  background: rgb(27 35 64 / .6);
+}
+[data-skin="dash"] .item { position: relative; padding: 2px; }
+[data-skin="dash"] .item::before {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: 5px;
+  background: #1B2340;
+  border: 2.5px solid #3EF0D0;
+  box-shadow: 0 0 8px rgb(62 240 208 / .55), inset 0 0 6px rgb(62 240 208 / .3);
+}
+[data-skin="dash"] .item:nth-child(even)::before { border-color: #FF4FD8; box-shadow: 0 0 8px rgb(255 79 216 / .5), inset 0 0 6px rgb(255 79 216 / .3); }
+[data-skin="dash"] .item svg { position: relative; scale: .68; }
+[data-skin="dash"] .tube.done { box-shadow: 0 0 0 3px #3EF0D0, 0 0 18px 5px rgb(62 240 208 / .6); }
+
+/* kawaii pop: chunky pastel squircles, soft everything, an aesthetic tribute */
+[data-skin="kawaii"] .tube {
+  border: .22rem solid #E8A9C4;
+  border-radius: 1.3rem;
+  background: rgb(255 227 238 / .75);
+}
+[data-skin="kawaii"] .item { position: relative; }
+[data-skin="kawaii"] .item::before {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: 38%;
+  background: #FFF6FA;
+  border: 2.5px solid #E8A9C4;
+  box-shadow: inset 0 -4px 0 rgb(232 169 196 / .35);
+}
+[data-skin="kawaii"] .item svg { position: relative; scale: .74; }
+[data-skin="kawaii"] .tube.sel { box-shadow: 0 .35rem 0 #E8A9C4; }
+
 /* the selected lift and done cues stay identical across skins on purpose:
    the READING of the board never changes, only its costume */
 

--- a/skins.js
+++ b/skins.js
@@ -32,6 +32,26 @@ export const SKINS = [
     motion: { rotate: 180, ease: 'cubic-bezier(.34,1.45,.6,1)', seconds: .3 },
     preview: '<rect x="20" y="38" width="24" height="18" fill="#79B84C" stroke="#3D3230" stroke-width="3"/><rect x="20" y="18" width="24" height="18" fill="#B98A5A" stroke="#3D3230" stroke-width="3"/>',
   },
+  // the three below are aesthetic tributes, deliberately NOT the trademarks:
+  // the look is the homage, the name stays ours.
+  {
+    key: 'voxel',
+    title: 'Voxel Mine',
+    motion: { rotate: 180, ease: 'cubic-bezier(.3,1.3,.55,1)', seconds: .28 },
+    preview: '<rect x="18" y="36" width="28" height="22" fill="#8A6142" stroke="#3D3230" stroke-width="3"/><rect x="18" y="14" width="28" height="22" fill="#8A6142" stroke="#3D3230" stroke-width="3"/><rect x="18" y="14" width="28" height="7" fill="#6FA644" stroke="#3D3230" stroke-width="3"/>',
+  },
+  {
+    key: 'dash',
+    title: 'Neon Dash',
+    motion: { rotate: -360, ease: 'cubic-bezier(.5,0,.2,1)', seconds: .26 },
+    preview: '<rect x="6" y="6" width="52" height="52" rx="6" fill="#141A2E"/><rect x="20" y="34" width="20" height="20" rx="3" fill="#1B2340" stroke="#3EF0D0" stroke-width="3"/><rect x="20" y="11" width="20" height="20" rx="3" fill="#1B2340" stroke="#FF4FD8" stroke-width="3"/>',
+  },
+  {
+    key: 'kawaii',
+    title: 'Kawaii Pop',
+    motion: { rotate: 24, ease: 'cubic-bezier(.3,1.75,.5,1)', seconds: .32 },
+    preview: '<rect x="18" y="8" width="28" height="48" rx="14" fill="#FFE3EE" stroke="#3D3230" stroke-width="3"/><circle cx="32" cy="44" r="9" fill="#FFB7D2" stroke="#3D3230" stroke-width="2.6"/><circle cx="32" cy="23" r="9" fill="#BFE8FF" stroke="#3D3230" stroke-width="2.6"/>',
+  },
 ]
 
 const KEY = 'sortit:skin'

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   3. only ok responses get cached, and the write is wrapped in waitUntil.
 //
 // bump CACHE when the shell list changes.
-const CACHE = 'sortit-v5'
+const CACHE = 'sortit-v6'
 const SHELL = [
   './',
   './index.html',


### PR DESCRIPTION
Closes #10. Verified in a phone-profile browser: all three render, wear their data-skin, and play a real move; picker shows 7 cards; zero console errors. Screenshots on the issue thread.