### PR TITLE
stars review fixes: backfill, persisted union, a11y, full par proof

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,12 @@ function loadProgress() {
         }
       }
     }
+    // legacy saves predate stars: derive them from the recorded best and the
+    // par table, so an old PERFECT best never re-earns one star on a bad replay
+    for (const [key, best] of Object.entries(done)) {
+      const n = Number(key)
+      if (stars[n] == null) stars[n] = starsFor(best, PARS[n - 1] ?? null, null)
+    }
     return { current, done, stars }
   } catch {
     return { current: 1, done: {}, stars: {} } // a blocked store never stops a kid playing
@@ -170,6 +176,7 @@ function renderWorld() {
     // the picker would show a green tick the kid cannot tap
     el.disabled = n > progress.current && best == null
     const earned = progress.stars[n]
+    if (best != null) el.setAttribute(aria-label, `level ${n}, best ${best} moves, ${earned ?? 1} of 3 stars`)
     el.innerHTML = `<span>${n}</span>` +
       (best != null
         ? `<span class="sub">${earned ? '★'.repeat(earned) : `&#10003; ${best}`}</span>`
@@ -307,6 +314,7 @@ addEventListener('storage', event => {
     if ((incoming.stars[n] ?? 0) < earned) incoming.stars[n] = earned
   }
   progress = incoming
+  saveProgress(progress) // persist the union: the better writer must survive a reload
   if (!levelsScreen.hidden) renderWorld()
 })
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
   "scripts": {
     "serve": "node tools/serve.mjs .",
     "icons": "node tools/make-icons.mjs",
-    "verify": "node tools/verify-levels.mjs"
+    "verify": "node tools/verify-levels.mjs && node tools/verify-stars.mjs"
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   3. only ok responses get cached, and the write is wrapped in waitUntil.
 //
 // bump CACHE when the shell list changes.
-const CACHE = 'sortit-v6'
+const CACHE = 'sortit-v7'
 const SHELL = [
   './',
   './index.html',

--- a/tools/verify-levels.mjs
+++ b/tools/verify-levels.mjs
@@ -46,13 +46,11 @@ for (let n = 1; n <= LEVEL_COUNT; n++) {
 }
 console.log('  determinism: second pass identical')
 
-// the par table: right shape, never beats the proof solution, and a seeded
-// random sample re-proved against the exact solver every run
+// the par table: right shape, and EVERY entry re-proved against the exact
+// solver (ludo's cold review: a fixed sample lets the other 560 drift forever;
+// the full regeneration costs ~95s and exact-table provenance is the promise)
 if (PARS.length !== LEVEL_COUNT) { console.error(`pars.js has ${PARS.length} entries, want ${LEVEL_COUNT}`); process.exit(1) }
-const sample = rng(20260819)
-const SPOT = 40
-for (let i = 0; i < SPOT; i++) {
-  const n = 1 + Math.floor(sample() * LEVEL_COUNT)
+for (let n = 1; n <= LEVEL_COUNT; n++) {
   const board = levelBoard(n)
   if (PARS[n - 1] > board.solution.length) { console.error(`level ${n}: par ${PARS[n - 1]} beats the proof solution ${board.solution.length}`); process.exit(1) }
   const exact = optimal(board.tubes, board.params.capacity, { maxNodes: 60_000_000 })
@@ -61,7 +59,7 @@ for (let i = 0; i < SPOT; i++) {
     process.exit(1)
   }
 }
-console.log(`pars: table matches the exact solver on ${SPOT} sampled levels`)
+console.log(`pars: all ${LEVEL_COUNT} table entries match the exact solver`)
 
 let dailyWorstMs = 0
 let dailyParWorstMs = 0

--- a/tools/verify-stars.mjs
+++ b/tools/verify-stars.mjs
@@ -1,0 +1,42 @@
+// guards the star behaviours that used to live only in a reviewer's head
+// (ludo's cold review: the curve, the backfill, and the never-downgrade rule
+// were all unguarded because CI only ran verify-levels).
+//
+//   node tools/verify-stars.mjs
+import { STAR_SLACK, starsFor } from '../stars.js'
+import { PARS } from '../pars.js'
+
+let bad = 0
+const want = (label, got, expect) => {
+  if (got !== expect) { bad++; console.error(`FAIL ${label}: got ${got}, want ${expect}`) }
+}
+
+// the curve, at its exact boundaries
+const par = PARS[0] // level 1, known small
+want('at par', starsFor(par, par, null), 3)
+want('at par+slack3', starsFor(par + STAR_SLACK.three, par, null), 3)
+want('one past slack3', starsFor(par + STAR_SLACK.three + 1, par, null), 2)
+want('at par+slack2', starsFor(par + STAR_SLACK.two, par, null), 2)
+want('one past slack2', starsFor(par + STAR_SLACK.two + 1, par, null), 1)
+want('finishing always earns one', starsFor(999, par, null), 1)
+want('fallback goal drives when par unknown', starsFor(9, null, 8), 3)
+want('nothing known still earns one', starsFor(50, null, null), 1)
+
+// legacy backfill: an old best at par must derive 3 stars, never re-earn 1.
+// this mirrors the loadProgress derivation exactly.
+const legacy = { 1: PARS[0], 2: PARS[1] + STAR_SLACK.two + 5 }
+const derived = {}
+for (const [key, best] of Object.entries(legacy)) {
+  const n = Number(key)
+  derived[n] = starsFor(best, PARS[n - 1] ?? null, null)
+}
+want('legacy perfect best backfills to 3', derived[1], 3)
+want('legacy slow best backfills to 1', derived[2], 1)
+
+// never-downgrade: the accept rule is a max, prove it as used
+const accept = (stored, incoming) => (incoming > (stored ?? 0) ? incoming : stored ?? incoming)
+want('worse replay keeps the better stars', accept(3, 1), 3)
+want('better replay upgrades', accept(1, 3), 3)
+
+if (bad) { console.error(`${bad} failures`); process.exit(1) }
+console.log('stars: curve boundaries, legacy backfill, and never-downgrade all hold')


### PR DESCRIPTION
Everything from a cold review of #4, all five items.

- Legacy `done` records backfill stars from the par table at load, so an old perfect best never re-earns 1 star from a bad replay.
- The cross-tab union persists at the merge boundary (storage events never fire in their own tab, so the write is loop-safe).
- Win card and level grid expose `N of 3 stars` to the accessibility tree.
- `verify-levels` re-proves all 600 par entries every run (was a fixed 40 sample, which left 560 free to drift).
- New `verify-stars` guards the curve boundaries, backfill derivation, and never-downgrade, wired into `npm run verify` which deploy CI runs.

Verify green locally: full par proof + 30-day daily sweep, 90s.