### PR TITLE
the about block carries roy's real maker's mark

### DIFF
--- a/app.css
+++ b/app.css
@@ -508,3 +508,17 @@ dialog li { margin-bottom: .3rem; }
   .tube.hint { box-shadow: 0 0 0 .3rem var(--accent); }
   .tube.shake { border-color: #C0392B; }
 }
+
+/* roy's maker's mark, the house colophon (canonical: blame-web MakerMark.svelte) */
+.maker-mark {
+  margin: 1rem 0 .2rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: .8rem;
+  color: var(--soft, #8b8f99);
+  text-align: center;
+}
+.maker-mark a { color: var(--ink, inherit); text-decoration: underline; }
+.maker-mark a.mark-sponsor { color: #d9a441; }
+.mark-heart { width: .85em; height: .85em; fill: #e0746a; vertical-align: -.1em; }
+.mark-dot { opacity: .45; }
+.sr { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }

--- a/index.html
+++ b/index.html
@@ -109,11 +109,13 @@
 <!-- ============ about: the made-with-love block, in-app ============ -->
 <dialog id="about">
   <h2>About</h2>
-  <p class="small">made with love by roy and ai.</p>
   <p class="small">no ads, no lives, no timers, nothing to buy, no accounts, no cookies, nothing
   sold or shared. that is the whole point.</p>
-  <p class="small">want to say thanks? find us at
-  <a href="https://github.com/royashbrook" target="_blank" rel="noopener">github.com/royashbrook</a>.</p>
+  <p class="maker-mark">made with <svg aria-hidden="true" class="mark-heart" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg><span class="sr">love</span> by
+  <a href="https://royashbrook.com" target="_blank" rel="noreferrer">roy</a> +
+  <a href="https://royashbrook.com/agents" target="_blank" rel="noreferrer">ai</a>
+  <span aria-hidden="true" class="mark-dot">&middot;</span>
+  <a href="https://github.com/sponsors/royashbrook" target="_blank" rel="noreferrer" class="mark-sponsor">sponsor me</a></p>
   <button id="about-close" class="big">BACK</button>
 </dialog>
 

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   3. only ok responses get cached, and the write is wrapped in waitUntil.
 //
 // bump CACHE when the shell list changes.
-const CACHE = 'sortit-v8'
+const CACHE = 'sortit-v9'
 const SHELL = [
   './',
   './index.html',


### PR DESCRIPTION
Refs #13 (the about issue). The about should carry the REAL footer from blame.today / mtok, not a paraphrase. Ported from the canonical blame-web `MakerMark.svelte` as vanilla html/css. Checker 27/27 locally under the strengthened mark rules.
