### PR TITLE
in-game bottom nav: menu/hint/undo/reset in the house bar

### DIFF
--- a/app.css
+++ b/app.css
@@ -121,9 +121,34 @@ h1 {
 #board-label { flex: 1; text-align: left; padding-inline: .2rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 #sound.muted { text-decoration: line-through; opacity: .6; }
 
-/* the in-game controls live at the BOTTOM, where a kid's thumb already is */
-.actions { display: flex; gap: .6rem; width: 100%; }
-.actions .chip { flex: 1; min-height: 3rem; }
+/* the in-game bottom nav: the house bar shape (craftrush / quarry). icon over a
+   tiny label reads at a glance and takes LESS height than the old fat chip row,
+   which gives the board back its vertical space. MENU is always one thumb away. */
+#game-nav {
+  display: flex;
+  gap: .3rem;
+  width: 100%;
+  padding: .35rem .4rem;
+  border-radius: 1.1rem;
+  background: rgb(61 50 48 / .92);
+}
+#game-nav button {
+  flex: 1;
+  display: grid;
+  place-items: center;
+  gap: .05rem;
+  min-height: 2.9rem;
+  padding: .3rem 0;
+  border: 0;
+  border-radius: .8rem;
+  background: var(--card);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+#game-nav button span { font-size: 1.1rem; line-height: 1; }
+#game-nav button b { font-size: .62rem; font-weight: 800; letter-spacing: .02em; }
+#game-nav button:active { transform: translateY(.1rem); }
 
 /* ------------------------------------------------------------------- board */
 

--- a/index.html
+++ b/index.html
@@ -53,7 +53,6 @@
 <!-- ============ game ============ -->
 <main id="game" class="screen" hidden>
   <header class="bar">
-    <button id="back" class="chip" aria-label="back to menu">&larr;</button>
     <span id="board-label" class="chip flat"></span>
     <span id="clock" class="chip flat mono" aria-label="time elapsed">0:00</span>
     <span id="moves" class="chip flat mono" aria-live="polite">0 moves</span>
@@ -61,11 +60,12 @@
 
   <div id="board" aria-label="sorting board"></div>
 
-  <div class="actions">
-    <button id="hint" class="chip">&#10024; HINT</button>
-    <button id="undo" class="chip">&#8630; UNDO</button>
-    <button id="reset" class="chip">&#8635; RESET</button>
-  </div>
+  <nav id="game-nav" aria-label="Game controls">
+    <button id="back" aria-label="Back to menu"><span aria-hidden="true">&#9776;</span><b>MENU</b></button>
+    <button id="hint"><span aria-hidden="true">&#10024;</span><b>HINT</b></button>
+    <button id="undo"><span aria-hidden="true">&#8630;</span><b>UNDO</b></button>
+    <button id="reset"><span aria-hidden="true">&#8635;</span><b>RESET</b></button>
+  </nav>
 
   <div id="stuck" class="stuck" hidden>
     <p>no moves left!</p>

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //   3. only ok responses get cached, and the write is wrapped in waitUntil.
 //
 // bump CACHE when the shell list changes.
-const CACHE = 'sortit-v10'
+const CACHE = 'sortit-v11'
 const SHELL = [
   './',
   './index.html',


### PR DESCRIPTION
Refs #13. The puzzle already carried a bottom action row (hint/undo/reset), just as fat full-width chips eating more height than quarry's real nav bar. Now they sit in the house bottom-nav shape (icon over a tiny label), more compact, and MENU is always one thumb away. Back leaves the header, the board gets the reclaimed height. Checker 27/27, all four buttons wired (verified undo rewinds the move count and MENU reaches the menu).
