### PR TITLE
wire copy-lint into the svelte gates (refs #13)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
+      # no banned public copy ships (false-privacy, em-dash) across *.md/*.html/*.svelte
+      - run: npm run lint:copy
       # the verifier IS the test suite: every level + 3 years of dailies must be
       # solvable, deterministic, and pars must match the exact solver before deploy
       - run: npm run verify

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,6 +18,9 @@ jobs:
         with:
           node-version: 22
       - run: npm ci
+      # the public copy carries no banned claim (false-privacy, em-dash), scanning
+      # *.md/*.html AND *.svelte so the about/footer/maker-mark text is covered
+      - run: npm run lint:copy
       # the deterministic guarantee: every level + 3 years of dailies solvable,
       # pars exact against the solver, determinism, star invariants
       - run: npm run verify

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -2,7 +2,7 @@
 
 local issue log (no remote yet). commits reference these numbers.
 
-## #1 — build "Sort It" to a releasable, locally-testable state
+## #1: build "Sort It" to a releasable, locally-testable state
 
 a kids' ball-sort puzzle PWA per the kidgames house standard
 (~/gh/kidgames/STANDARD.md). scope:
@@ -13,7 +13,7 @@ a kids' ball-sort puzzle PWA per the kidgames house standard
 - offline-first service worker, install helper, update banner
 - unlimited undo, hint, no ads / no lives / no timers / nothing to buy
 
-status: open — releasable local state reached 2026-08-18; remaining: deploy + real-device install checks
+status: open, releasable local state reached 2026-08-18. remaining: deploy + real-device install checks
 
 ### adversarial review 2026-08-18 (6 reviewers, all findings triaged)
 
@@ -44,7 +44,7 @@ fixed:
 
 deferred (viewed, judged low):
 - back mid-level discards the attempt (no mid-level persistence yet)
-- hint treats a solver budget abort as "lost" — empirically unreachable
+- hint treats a solver budget abort as "lost", empirically unreachable
   (600 starts + 400 dailies + adversarial mid-game walks all solve <8k nodes)
 - landscape browser tab on a very short window can still crowd the header
   (installed app is portrait-locked; menu/picker scroll)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm run serve   # http://localhost:4310
 - **600 campaign levels** across 30 themed worlds (7 art themes rotating), plus
   a **daily puzzle** that is the same board for everyone in the world.
 - every board is dealt deterministically from its level number / date and
-  **proven solvable by an exact solver before it is shown** — see `solver.js`
+  **proven solvable by an exact solver before it is shown**: see `solver.js`
   and `levels.js`. `npm run verify` re-proves all 600 levels and 3 years of
   dailies in under a second.
 - unlimited **undo**, an honest **hint** (it replays the solver from your

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "svelte-check": "svelte-check --tsconfig ./jsconfig.json",
     "icons": "node tools/make-icons.mjs",
+    "lint:copy": "node tools/lint-copy.mjs",
     "verify": "node tools/verify-levels.mjs && node tools/verify-stars.mjs"
   },
   "devDependencies": {

--- a/src/lib/engine/art/ART-SPEC.md
+++ b/src/lib/engine/art/ART-SPEC.md
@@ -25,7 +25,7 @@ each item:
   two items that differ only by colour are a spec violation.
 - style: flat warm fills, bold `#3D3230` outline at stroke-width 3
   (stroke-linejoin/linecap round), one friendly face per item (two dot eyes +
-  a smile — copy the `face()` helper in `shapes.js`), optional tiny highlight.
+  a smile, copy the `face()` helper in `shapes.js`), optional tiny highlight.
   warm and cosy over slick. calm, not loud.
 - no raster data, no external refs, no <image>, no gradients-heavy filters.
   plain shapes: path/circle/rect/ellipse/line/polygon/g only.

--- a/tools/lint-copy.mjs
+++ b/tools/lint-copy.mjs
@@ -1,0 +1,52 @@
+// copy lint for the repo's own public text.
+//
+//   node tools/lint-copy.mjs
+//
+// verify-levels/verify-stars prove the ENGINE. nothing proved the repo's own
+// words, which is how a "no tracking" claim (banned by the standard, we run a
+// cookieless beacon) could ship and only a human catch it. this closes that hole
+// and is par's carry-forward from the svelte pilot: the vanilla lint scanned only
+// *.md/*.html, but svelte moves the about/footer/maker-mark copy into *.svelte, so
+// those files are added to the glob or the very copy svelte introduced goes unseen.
+//
+// the trap this is built around: the rule text itself has to quote the banned
+// phrase, so a naive grep flags the very lines that define the rule. rather than
+// guess at intent, a line opts out explicitly with a `copy-lint-ok` marker: a
+// comment about why. no heuristics, no false positives.
+import { readFileSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+
+const MARKER = 'copy-lint-ok'
+
+const RULES = [
+  {
+    name: 'false privacy claim',
+    // banned outright in our copy: we run a beacon, so these sentences are not true
+    test: /\bno tracking\b|\bno analytics\b|\bwe do ?n'?o?t track\b/i,
+    why: 'we run a cookieless beacon, so this is false. use the ethos line from the standard.',
+  },
+  {
+    name: 'em-dash',
+    test: /—|\s--\s/,
+    why: 'house voice uses a colon, a comma, or parentheses instead.',
+  },
+]
+
+const files = execSync("git ls-files '*.md' '*.html' '*.svelte'", { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean)
+
+const hits = []
+for (const file of files) {
+  const lines = readFileSync(file, 'utf8').split('\n')
+  lines.forEach((line, i) => {
+    if (line.includes(MARKER)) return
+    for (const rule of RULES) {
+      if (rule.test.test(line)) hits.push({ file, line: i + 1, rule, text: line.trim().slice(0, 90) })
+    }
+  })
+}
+
+for (const h of hits) console.log(`${h.file}:${h.line}  ${h.rule.name}\n    ${h.text}\n    ${h.rule.why}`)
+console.log(hits.length ? `\n${hits.length} problem(s) in ${files.length} files` : `clean: ${files.length} files`)
+process.exit(hits.length ? 1 : 0)


### PR DESCRIPTION
par's carry-forward from the svelte pilot brand gate.

## what
- port `tools/lint-copy.mjs` into sortit (the svelte reference every conversion inherits)
- **add `*.svelte` to the glob**: the vanilla lint scanned only `*.md`/`*.html`, but svelte moves the about/footer/maker-mark copy into `*.svelte`. without this the copy svelte introduced goes unlinted, which is the exact gap par flagged.
- `lint:copy` npm script, wired into **both** `pr-check` and `deploy-site` before `verify`
- fixed 5 pre-existing em-dashes in repo docs (ISSUES/README/ART-SPEC) the lint correctly flagged

## proof
`npm run lint:copy` → `clean: 9 files`. pr-gate re-runs it here.