### PR TITLE
adopt the shell theme-token standard (refs #25)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,13 +2,26 @@
    system font stack only: a webfont is a third-party request with a kid's IP on
    it, and it costs offline-first (see STANDARD.md). */
 :root {
-  --bg: #FFF6E5;
+  /* the house SHELL THEME TOKENS (kidgames docs/shell-theme-tokens.md). structure is
+     fixed, look is a swappable layer: a theme sets these values and nothing else.
+     themes.js writes them onto the root, so these are the daylight defaults. */
+  --surface: #FFF6E5;
+  --surface-raised: #FFFFFF;
+  --surface-sunk: #FFEED2;
   --ink: #3D3230;
-  --soft: #8A7A70;
+  --ink-dim: #8A7A70;
+  --ink-on-accent: #3D3230;
   --accent: #FFB03A;
-  --card: #FFFFFF;
+  --accent-dim: #E89B27;
   --line: #3D3230;
-  --tint: #FFEED2;
+
+  /* sortit's original names, kept as ALIASES so every existing rule keeps working and
+     a theme swap reaches all of them. new css should use the token names above. */
+  --bg: var(--surface);
+  --card: var(--surface-raised);
+  --tint: var(--surface-sunk);
+  --soft: var(--ink-dim);
+
   color: var(--ink);
   background: var(--bg);
   font-family: ui-rounded, "Arial Rounded MT Bold", "Nunito", system-ui, sans-serif;
@@ -584,3 +597,18 @@ dialog li { margin-bottom: .3rem; }
   opacity: .6;
   pointer-events: none;
 }
+
+/* the shell-theme picker (the skinnable rule's visible half). the swatch shows the
+   theme's own surface/accent/ink so the choice reads before it is applied. */
+.looks-sub { margin: 1.1rem 0 .5rem; font-size: 1rem; }
+.themes-row { display: flex; gap: .6rem; flex-wrap: wrap; }
+.theme-chip {
+  display: flex; align-items: center; gap: .5rem;
+  min-height: 44px; padding: .4rem .7rem;
+  border: .14rem solid var(--line); border-radius: .8rem;
+  background: var(--surface-raised); color: var(--ink);
+  font: inherit; font-size: .85rem; cursor: pointer;
+}
+.theme-chip[aria-pressed="true"] { background: var(--accent); color: var(--ink-on-accent); }
+.theme-swatch { display: inline-flex; border-radius: 999px; overflow: hidden; border: .1rem solid var(--line); }
+.theme-swatch i { display: block; width: 14px; height: 14px; }

--- a/src/lib/ui/store.svelte.js
+++ b/src/lib/ui/store.svelte.js
@@ -6,6 +6,8 @@ import { isComplete, isWin, solve } from '../engine/solver.js'
 import { THEMES, themeForWorld } from '../engine/art/index.js'
 import { STAR_SLACK, parFor, starsFor } from '../engine/stars.js'
 import { SKINS, loadSkin, saveSkin } from '../engine/skins.js'
+// the SHELL theme layer (the chrome's look), orthogonal to the game-art skin layer
+import { SHELL_THEMES, applyTheme, loadTheme, saveTheme } from './themes.js'
 import { dailySeed } from '../engine/seed.js'
 import { sound } from './sounds.js'
 import { confetti } from './confetti.js'
@@ -54,6 +56,7 @@ export function createStore() {
   let playSeq = 0                   // bumped per play(), so a stale deferred par lands nowhere
   let theme = $state(null)
   let skin = $state(loadSkin())
+  let shellTheme = $state(loadTheme())
   let progress = $state(loadProgress())
   let world = $state(0)
 
@@ -235,6 +238,8 @@ export function createStore() {
     get moveSeq() { return moveSeq },
     get lastMovedUids() { return lastMovedUids },
     get skins() { return SKINS },
+    get shellThemes() { return SHELL_THEMES },
+    get shellTheme() { return shellTheme },
     get boardLabel() {
       if (!board) return ''
       if (board.kind === 'level') return `level ${board.n}`
@@ -274,6 +279,7 @@ export function createStore() {
       return m
     },
     setSkin(next) { skin = next; saveSkin(next) },
+    setShellTheme(next) { shellTheme = next; saveTheme(next.key); applyTheme(next) },
     openDialog(d) { dialog = d },
     closeDialog() { dialog = null },
     // two tabs writing one store: adopt the better of the two rather than clobber

--- a/src/lib/ui/themes.js
+++ b/src/lib/ui/themes.js
@@ -1,0 +1,92 @@
+// the SHELL theme layer: the house standard's skinnable rule.
+//
+//   structure is shared and fixed, look and feel is a swappable layer.
+//   mechanism: kidgames docs/shell-theme-tokens.md
+//
+// this is NOT the game-art skin layer (skins.js: tubes vs bolts vs blocks, the
+// CONTAINER and the MOTION verb). the two are orthogonal on purpose: a theme repaints
+// the chrome and the board surround, a skin changes what the pieces ARE. you can run
+// any skin under any theme.
+//
+// a theme is nothing but token VALUES. no structure, no class names, no markup. that
+// is what makes it swappable, and what the theme-swap proof checks.
+
+const KEY = 'sortit:theme'
+
+export const THEME_TOKENS = [
+  '--surface', '--surface-raised', '--surface-sunk',
+  '--ink', '--ink-dim', '--ink-on-accent',
+  '--accent', '--accent-dim', '--line',
+]
+
+export const SHELL_THEMES = [
+  {
+    key: 'daylight',
+    title: 'Daylight',
+    swatch: ['#FFF6E5', '#FFB03A', '#3D3230'],
+    tokens: {
+      '--surface': '#FFF6E5',
+      '--surface-raised': '#FFFFFF',
+      '--surface-sunk': '#FFEED2',
+      '--ink': '#3D3230',
+      '--ink-dim': '#8A7A70',
+      '--ink-on-accent': '#3D3230',
+      '--accent': '#FFB03A',
+      '--accent-dim': '#E89B27',
+      '--line': '#3D3230',
+    },
+  },
+  {
+    key: 'dusk',
+    title: 'Dusk',
+    swatch: ['#241F2E', '#FFB03A', '#F2ECE2'],
+    tokens: {
+      '--surface': '#241F2E',
+      '--surface-raised': '#332B42',
+      '--surface-sunk': '#1B1724',
+      '--ink': '#F2ECE2',
+      '--ink-dim': '#B3A8BF',
+      '--ink-on-accent': '#241F2E',
+      '--accent': '#FFB03A',
+      '--accent-dim': '#D8912A',
+      '--line': '#F2ECE2',
+    },
+  },
+  {
+    key: 'bubblegum',
+    title: 'Bubblegum',
+    swatch: ['#FFF0F6', '#FF74A8', '#4A2740'],
+    tokens: {
+      '--surface': '#FFF0F6',
+      '--surface-raised': '#FFFFFF',
+      '--surface-sunk': '#FFE0EC',
+      '--ink': '#4A2740',
+      '--ink-dim': '#96718A',
+      '--ink-on-accent': '#FFFFFF',
+      '--accent': '#FF74A8',
+      '--accent-dim': '#E85C90',
+      '--line': '#4A2740',
+    },
+  },
+]
+
+export function themeByKey(key) {
+  return SHELL_THEMES.find(t => t.key === key) ?? SHELL_THEMES[0]
+}
+
+export function loadTheme() {
+  try { return themeByKey(localStorage.getItem(KEY)) } catch { return SHELL_THEMES[0] }
+}
+
+export function saveTheme(key) {
+  try { localStorage.setItem(KEY, key) } catch { /* private mode: the look just resets */ }
+}
+
+// paint by writing the token VALUES onto the root. nothing else moves: same DOM, same
+// class names, same structure, which is exactly the compliance bar.
+export function applyTheme(theme) {
+  if (typeof document === 'undefined') return
+  const root = document.documentElement
+  for (const [token, value] of Object.entries(theme.tokens)) root.style.setProperty(token, value)
+  root.dataset.theme = theme.key
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,11 @@
 <script>
   import '../app.css'
   import { onMount } from 'svelte'
+  import { applyTheme, loadTheme } from '$lib/ui/themes.js'
   let { children } = $props()
+
+  // paint the saved shell theme before anything else reads the tokens
+  onMount(() => applyTheme(loadTheme()))
 
   // register the service worker by hand (kit's is disabled) so dev never gets a
   // stale one, and only in the built app

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -219,6 +219,21 @@
           </button>
         {/each}
       </div>
+      <h2 class="looks-sub">Colours</h2>
+      <div class="themes-row">
+        {#each store.shellThemes as candidate}
+          <button
+            class="theme-chip"
+            aria-pressed={candidate.key === store.shellTheme.key}
+            onclick={() => store.setShellTheme(candidate)}
+          >
+            <span class="theme-swatch" aria-hidden="true">
+              {#each candidate.swatch as colour}<i style:background={colour}></i>{/each}
+            </span>
+            <span>{candidate.title}</span>
+          </button>
+        {/each}
+      </div>
       <p class="small">Same puzzles, different costume. Changing it never touches your game.</p>
       <button class="big" onclick={close}>DONE</button>
     {/snippet}


### PR DESCRIPTION
Closes #25.

Structure fixed, look swappable, per the house skinnable rule.

- canonical token set on `:root`; sortit's original names (`--bg`/`--card`/`--tint`/`--soft`) kept as **aliases** so every existing rule keeps working and a swap reaches all of them
- three themes in LOOKS: Daylight, Dusk, Bubblegum. Persisted, applied on boot
- SHELL layer only, orthogonal to the game-art skins. Any skin runs under any theme

**Proven in a real browser on the built site**, picking Dusk:

| | before | after | after reload |
|---|---|---|---|
| `--surface` | `#FFF6E5` | `#241F2E` | `#241F2E` |
| `--ink` | `#3D3230` | `#F2ECE2` | `#F2ECE2` |
| body background | cream | `rgb(36,31,46)` | `rgb(36,31,46)` |
| structure | 8 buttons, h1 | **8 buttons, h1** | **8 buttons, h1** |

Look swaps, structure does not move. Zero page errors.