### PR TITLE
the house bottom bar on every screen (refs #27)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -111,6 +111,17 @@
     <button class="big secondary" onclick={() => store.openDialog('about')}>ABOUT</button>
     <p class="ethos">no ads &middot; no timers &middot; nothing to buy &middot; no cookies</p>
   </main>
+  <!-- the house bottom bar, present on EVERY screen. same styling and placement
+       throughout; the CONTENTS are genre-appropriate (kidgames#5): tabs while you are
+       choosing, in-play controls while you are solving. a launch screen with no bar at
+       all is what this closes. -->
+  <nav id="game-nav" aria-label="Main">
+    <button onclick={() => store.startLevel(store.progress.current)} aria-label="Play"><span aria-hidden="true">&#9654;</span><b>PLAY</b></button>
+    <button onclick={() => store.openLevels()} data-active={store.screen === 'levels' ? '' : undefined} aria-label="Pick a level"><span aria-hidden="true">&#9776;</span><b>LEVELS</b></button>
+    <button onclick={() => store.openDialog('looks')} aria-label="Looks"><span aria-hidden="true">&#10024;</span><b>LOOKS</b></button>
+    <button onclick={() => store.openDialog('about')} aria-label="More"><span aria-hidden="true">&#9881;</span><b>MORE</b></button>
+  </nav>
+
 {/if}
 
 {#if store.screen === 'levels'}
@@ -146,6 +157,17 @@
       {Object.keys(store.progress.done).length ? `you've sorted ${Object.keys(store.progress.done).length} of ${LEVEL_COUNT} levels` : 'sort a level to leave your mark!'}
     </p>
   </main>
+  <!-- the house bottom bar, present on EVERY screen. same styling and placement
+       throughout; the CONTENTS are genre-appropriate (kidgames#5): tabs while you are
+       choosing, in-play controls while you are solving. a launch screen with no bar at
+       all is what this closes. -->
+  <nav id="game-nav" aria-label="Main">
+    <button onclick={() => store.startLevel(store.progress.current)} aria-label="Play"><span aria-hidden="true">&#9654;</span><b>PLAY</b></button>
+    <button onclick={() => store.openLevels()} data-active={store.screen === 'levels' ? '' : undefined} aria-label="Pick a level"><span aria-hidden="true">&#9776;</span><b>LEVELS</b></button>
+    <button onclick={() => store.openDialog('looks')} aria-label="Looks"><span aria-hidden="true">&#10024;</span><b>LOOKS</b></button>
+    <button onclick={() => store.openDialog('about')} aria-label="More"><span aria-hidden="true">&#9881;</span><b>MORE</b></button>
+  </nav>
+
 {/if}
 
 {#if store.screen === 'game'}


### PR DESCRIPTION
Closes #27.

The menu screen had no bottom bar at all, so opening sortit read as having no nav. Now the bar is on every screen, with constant placement and styling and genre-appropriate contents:

| screen | bar |
|---|---|
| menu | PLAY / LEVELS / LOOKS / MORE |
| levels | PLAY / LEVELS / LOOKS / MORE |
| in a solve | MENU / HINT / UNDO / RESET |

**Verified in a browser on the built site**, all three screens: bar present, visible, pinned to the bottom edge (844 of 844 at 390x844), zero page errors. svelte-check 0/0, copy lint clean.

(The commit message says `refs #26` in error, #26 is the theme-token PR. The squash message below carries the correct `#27`.)