### PR TITLE
total conversions: skin-owned pieces and motion (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -242,8 +242,9 @@ h1 {
 .item.hid svg { opacity: .9; }
 
 /* ===== skins: total board conversions, picked in LOOKS =====
-   the default rules above ARE Classic. conversion skins provide their own
-   twelve pieces; their css owns only the furniture and presentation. */
+   the default rules above ARE Classic. a conversion skin brings its own
+   twelve pieces (skinart/), so its css owns only the furniture (what the
+   pieces sit on) and the scene (what the board is). */
 
 /* an item mid-flight rides above every container on the board */
 .item.flying { position: relative; z-index: 30; }
@@ -251,63 +252,9 @@ h1 {
 /* the landing-effects canvas: above the board, below the win sheet */
 .fxlayer { position: fixed; inset: 0; z-index: 8; pointer-events: none; }
 
-/* glass: the flagship. a rounded vessel with a lit wall, an elliptical mouth,
-   and a running highlight; pieces become glossy pebbles inside it. */
-[data-skin="glass"] .tube {
-  border: 2px solid rgb(61 50 48 / .55);
-  border-top: 0;
-  border-radius: 14px 14px 22px 22px;
-  background:
-    linear-gradient(100deg, rgb(255 255 255 / .85) 4%, rgb(255 255 255 / .25) 22%, rgb(190 214 228 / .28) 60%, rgb(120 150 170 / .38) 96%);
-  box-shadow:
-    inset 4px 0 6px -3px rgb(255 255 255 / .9),
-    inset -5px 0 8px -3px rgb(70 100 125 / .45),
-    inset 0 -8px 10px -6px rgb(70 100 125 / .5),
-    0 6px 10px -4px rgb(61 50 48 / .35);
-}
-[data-skin="glass"] .tube::before { /* the mouth: an open ellipse at the rim */
-  content: '';
-  position: absolute;
-  top: -5px; left: 6%;
-  width: 88%; height: 10px;
-  border-radius: 50%;
-  border: 2px solid rgb(61 50 48 / .5);
-  background: linear-gradient(180deg, rgb(210 228 238 / .8), rgb(255 255 255 / .35));
-}
-[data-skin="glass"] .tube::after { /* the standing highlight streak */
-  content: '';
-  position: absolute;
-  top: 8%; left: 14%;
-  width: 9%; height: 82%;
-  border-radius: 99px;
-  background: linear-gradient(180deg, rgb(255 255 255 / .95), rgb(255 255 255 / .1));
-  pointer-events: none;
-}
-[data-skin="glass"] .item { position: relative; }
-[data-skin="glass"] .item::before { /* a glossy pebble under the face */
-  content: '';
-  position: absolute;
-  inset: 2px;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at 32% 26%, rgb(255 255 255 / .95) 0 18%, rgb(255 255 255 / 0) 42%),
-    radial-gradient(circle at 50% 115%, rgb(61 50 48 / .28) 0 45%, rgb(61 50 48 / 0) 70%),
-    #F4EFE7;
-  border: 2px solid rgb(61 50 48 / .6);
-  box-shadow: 0 3px 4px -2px rgb(61 50 48 / .4);
-}
-[data-skin="glass"] .item svg { position: relative; scale: .78; }
-[data-skin="glass"] .tube.sel {
-  transform: translateY(-4px);
-  box-shadow:
-    inset 4px 0 6px -3px rgb(255 255 255 / .9),
-    inset -5px 0 8px -3px rgb(70 100 125 / .45),
-    0 10px 14px -5px rgb(61 50 48 / .45);
-}
-
-/* nuts & bolts: a machined bolt up the middle, real hex nuts riding it.
-   the shaft's angled thread and the nut's turned bevel are what make the
-   screw-down landing read as threading, not spinning. */
+/* nuts & bolts: a machined bolt up the middle, coloured hex nuts riding it.
+   the shaft's angled thread and the nut's own bevel (in its svg) are what
+   make the screw-down landing read as threading, not spinning. */
 [data-skin="bolts"] .tube {
   border-color: transparent;
   border-bottom: .3rem solid var(--line);
@@ -338,155 +285,34 @@ h1 {
   border: 2px solid var(--line);
   border-radius: 4px;
 }
-[data-skin="bolts"] .item { position: relative; z-index: 1; padding: 1px; }
-[data-skin="bolts"] .item::before { /* a turned hex nut: brushed faces, bevel */
-  content: '';
-  position: absolute;
-  inset: 1px;
-  clip-path: polygon(25% 3%, 75% 3%, 98% 50%, 75% 97%, 25% 97%, 2% 50%);
-  background:
-    linear-gradient(145deg, rgb(255 255 255 / .85) 0 12%, rgb(255 255 255 / 0) 40%),
-    linear-gradient(0deg, rgb(0 0 0 / .28) 0 14%, rgb(0 0 0 / 0) 34%),
-    linear-gradient(90deg, #DDD5CB 0 25%, #C2B9AF 25% 75%, #9E958B 75%),
-    #C2B9AF;
-}
-[data-skin="bolts"] .item::after { /* the threaded bore behind the face */
-  content: '';
-  position: absolute;
-  inset: 26%;
-  border-radius: 50%;
-  background: radial-gradient(circle at 40% 35%, #7A726A, #4A443E 70%);
-  box-shadow: inset 0 2px 3px rgb(0 0 0 / .5), inset 0 -1px 2px rgb(255 255 255 / .25);
-}
-[data-skin="bolts"] .item svg { position: relative; z-index: 1; scale: .68; }
+[data-skin="bolts"] .item { position: relative; z-index: 1; padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
+[data-skin="bolts"] .item svg { scale: .96; }
 [data-skin="bolts"] .tube.sel { box-shadow: none; }
 
-/* beads & sticks: a lathed wooden dowel, lacquered beads with a sheen */
-[data-skin="beads"] .tube {
+/* block mine: a bright day over dug shafts. the pieces are 2.5d cubes with
+   their own faces, so the scene only has to be sky, a grass horizon, and
+   the dark of the columns. an aesthetic tribute. */
+#board[data-skin="mine"] {
+  background:
+    radial-gradient(circle at 78% 10%, rgb(255 240 170 / .55), transparent 16%),
+    linear-gradient(180deg, #8FD0F7 0 24%, #B9E4FF 24% 30%, #7FBF4E 30% 32.5%, #5A3F2C 32.5% 100%) !important;
+}
+[data-skin="mine"] .tube {
   border-color: transparent;
-  border-bottom: .3rem solid var(--line);
+  border-bottom: .35rem solid #2B2118;
   border-radius: 0;
-  background: transparent;
+  background: linear-gradient(90deg, rgb(0 0 0 / .22), rgb(0 0 0 / .08) 30% 70%, rgb(0 0 0 / .26));
+  padding: 0 1px 5px;
 }
-[data-skin="beads"] .tube::before {
-  content: '';
-  position: absolute;
-  inset: 4px auto 5px 50%;
-  width: 8px;
-  translate: -50% 0;
-  background: linear-gradient(90deg, #C8B091 0 30%, #A98F71 55%, #7E6850);
-  border: 2px solid var(--line);
-  border-radius: 4px;
-  box-shadow: 2px 0 4px -1px rgb(61 50 48 / .35);
+[data-skin="mine"] .item {
+  padding: 0;
+  filter: drop-shadow(0 4px 2px rgb(26 20 16 / .38));
 }
-[data-skin="beads"] .tube::after { /* the dowel's rounded tip */
-  content: '';
-  position: absolute;
-  top: -2px; left: 50%;
-  width: 14px; height: 12px;
-  translate: -50% 0;
-  border-radius: 50%;
-  background: radial-gradient(circle at 35% 30%, #D8C4A6, #8A7458 75%);
-  border: 2px solid var(--line);
-}
-[data-skin="beads"] .item { position: relative; z-index: 1; }
-[data-skin="beads"] .item::before {
-  content: '';
-  position: absolute;
-  inset: 2px;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at 32% 26%, rgb(255 255 255 / .9) 0 16%, rgb(255 255 255 / 0) 40%),
-    radial-gradient(circle at 55% 110%, rgb(61 50 48 / .22) 0 45%, rgb(61 50 48 / 0) 70%),
-    #FFF3DD;
-  border: 2.5px solid var(--line);
-  box-shadow: 0 3px 4px -2px rgb(61 50 48 / .4);
-}
-[data-skin="beads"] .item svg { position: relative; scale: .72; }
-[data-skin="beads"] .tube.sel { box-shadow: none; }
+[data-skin="mine"] .item svg { scale: .96; overflow: visible; image-rendering: pixelated; }
+[data-skin="mine"] .tube.done { box-shadow: 0 0 0 3px #8FCC5E, 0 0 16px 4px rgb(143 204 94 / .55); }
 
-/* block stacks: toy bricks with a molded top and a real drop shadow */
-[data-skin="blocks"] .tube {
-  border-color: transparent;
-  border-bottom: .35rem solid var(--line);
-  border-radius: 0;
-  background: transparent;
-  padding: 0 2px 5px;
-}
-[data-skin="blocks"] .item { position: relative; padding: 1px; }
-[data-skin="blocks"] .item::before {
-  content: '';
-  position: absolute;
-  inset: 2px;
-  border-radius: 5px;
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / .6) 0 12%, rgb(255 255 255 / 0) 30%),
-    linear-gradient(90deg, rgb(255 255 255 / .25) 0 8%, rgb(0 0 0 / 0) 20% 78%, rgb(0 0 0 / .18) 92%),
-    #EDE3D4;
-  border: 3px solid var(--line);
-  box-shadow:
-    inset 0 -6px 0 -2px rgb(61 50 48 / .22),
-    0 4px 5px -3px rgb(61 50 48 / .45);
-}
-[data-skin="blocks"] .item::after { /* two molded studs on the top edge */
-  content: '';
-  position: absolute;
-  top: 4px; left: 24%;
-  width: 52%; height: 6px;
-  background:
-    radial-gradient(circle at 25% 50%, rgb(255 255 255 / .8) 0 22%, rgb(61 50 48 / .3) 30% 40%, transparent 45%),
-    radial-gradient(circle at 75% 50%, rgb(255 255 255 / .8) 0 22%, rgb(61 50 48 / .3) 30% 40%, transparent 45%);
-}
-[data-skin="blocks"] .item svg { position: relative; scale: .68; }
-
-/* voxel mine: 2.5d dirt cubes, grass-capped. every block's top face pokes up
-   into the block above and gets covered by it, so only the top of each stack
-   shows grass, exactly like a dug column. an aesthetic tribute. */
-/* both full-scene boards must beat the inline theme tint Board.svelte sets */
-#board[data-skin="voxel"] {
-  background: linear-gradient(180deg, #BFE0F5 0 26%, #9BC7E8 32%, #7B5B41 38%, #5C4430 100%) !important;
-}
-[data-skin="voxel"] .tube {
-  border-color: transparent;
-  border-bottom: .35rem solid #3A2C1F;
-  border-radius: 0;
-  background: transparent;
-  padding: 0 2px 5px;
-}
-[data-skin="voxel"] .item { position: relative; padding: 0; }
-[data-skin="voxel"] .item::before { /* the front face: coarse dirt, hard light */
-  content: '';
-  position: absolute;
-  inset: 1px;
-  border: 2px solid var(--line);
-  background:
-    linear-gradient(90deg, rgb(255 255 255 / .16) 0 10%, rgb(0 0 0 / 0) 24% 70%, rgb(0 0 0 / .28) 88%),
-    repeating-conic-gradient(#8A6142 0% 25%, #7A5238 25% 50%) 0 0 / 8px 8px;
-  box-shadow: inset 0 -5px 0 rgb(0 0 0 / .25);
-  image-rendering: pixelated;
-}
-/* only the TOP block of a stack wears grass: what a dug column looks like.
-   items stack bottom-up in a column-reverse flex, so the stack top is the
-   last child. */
-[data-skin="voxel"] .item:last-child::before {
-  background:
-    linear-gradient(0deg, rgb(0 0 0 / 0) 72%, #6FA644 72% 82%, #7FBF4E 82%),
-    linear-gradient(90deg, rgb(255 255 255 / .16) 0 10%, rgb(0 0 0 / 0) 24% 70%, rgb(0 0 0 / .28) 88%),
-    repeating-conic-gradient(#8A6142 0% 25%, #7A5238 25% 50%) 0 0 / 8px 8px;
-}
-[data-skin="voxel"] .item:last-child::after { /* its 2.5d grass lid, set back-right */
-  content: '';
-  position: absolute;
-  top: -5px; left: 5px; right: -3px;
-  height: 7px;
-  transform: skewX(-38deg);
-  background: linear-gradient(90deg, #8FCC5E 0 55%, #6FA644 55%);
-  border: 2px solid var(--line);
-}
-[data-skin="voxel"] .item svg { position: relative; z-index: 1; scale: .64; }
-[data-skin="voxel"] .tube.done { box-shadow: 0 0 0 3px #46A758, 0 0 16px 4px rgb(70 167 88 / .55); }
-
-/* neon dash: dark grid, glowing cube outlines, an aesthetic tribute */
+/* neon dash: dark grid, glowing lanes, icons with their own glow. an
+   aesthetic tribute. */
 #board[data-skin="dash"] {
   background:
     linear-gradient(rgb(62 240 208 / .06) 1px, transparent 1px) 0 0 / 100% 28px,
@@ -500,78 +326,11 @@ h1 {
   background: linear-gradient(180deg, rgb(27 35 64 / .35), rgb(27 35 64 / .85));
   box-shadow: inset 0 0 12px rgb(62 240 208 / .12);
 }
-[data-skin="dash"] .item { position: relative; padding: 2px; }
-[data-skin="dash"] .item::before {
-  content: '';
-  position: absolute;
-  inset: 3px;
-  border-radius: 5px;
-  background: linear-gradient(145deg, #232D52, #161D38 60%);
-  border: 2.5px solid #3EF0D0;
-  box-shadow: 0 0 8px rgb(62 240 208 / .55), inset 0 0 6px rgb(62 240 208 / .3);
-}
-[data-skin="dash"] .item:nth-child(even)::before { border-color: #FF4FD8; box-shadow: 0 0 8px rgb(255 79 216 / .5), inset 0 0 6px rgb(255 79 216 / .3); }
+[data-skin="dash"] .item { position: relative; padding: 0; }
+[data-skin="dash"] .item svg { scale: .92; filter: drop-shadow(0 0 5px rgb(62 240 208 / .38)); }
 [data-skin="dash"] .item.flying { filter: drop-shadow(0 0 8px rgb(62 240 208 / .8)); }
-[data-skin="dash"] .item svg { position: relative; scale: .68; }
 [data-skin="dash"] .tube.done { box-shadow: 0 0 0 3px #3EF0D0, 0 0 18px 5px rgb(62 240 208 / .6); }
 
-/* kawaii pop: chunky pastel squircles, soft everything, an aesthetic tribute */
-[data-skin="kawaii"] .tube {
-  border: .22rem solid #E8A9C4;
-  border-radius: 1.3rem;
-  background: linear-gradient(180deg, rgb(255 236 244 / .9), rgb(255 214 231 / .75));
-  box-shadow: inset 0 4px 8px -4px rgb(255 255 255 / .9), 0 5px 8px -4px rgb(232 169 196 / .7);
-}
-[data-skin="kawaii"] .item { position: relative; }
-[data-skin="kawaii"] .item::before {
-  content: '';
-  position: absolute;
-  inset: 3px;
-  border-radius: 38%;
-  background:
-    radial-gradient(circle at 32% 24%, rgb(255 255 255 / .95) 0 20%, rgb(255 255 255 / 0) 46%),
-    #FFF6FA;
-  border: 2.5px solid #E8A9C4;
-  box-shadow: inset 0 -4px 0 rgb(232 169 196 / .35), 0 3px 5px -2px rgb(232 169 196 / .8);
-}
-[data-skin="kawaii"] .item svg { position: relative; scale: .74; }
-[data-skin="kawaii"] .tube.sel { box-shadow: 0 .35rem 0 #E8A9C4; }
-
-/* v1 total conversions. The earlier costume selectors stay harmless while
-   the branch is in flight; these later rules remove their shared backings so
-   each conversion's SVG is the complete piece, not a theme face on a prop. */
-[data-skin="bolts"] .item::before,
-[data-skin="bolts"] .item::after,
-[data-skin="dash"] .item::before,
-[data-skin="dash"] .item::after { content: none; }
-
-[data-skin="bolts"] .item { padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
-[data-skin="bolts"] .item svg { scale: .96; }
-
-#board[data-skin="mine"] {
-  background:
-    radial-gradient(circle at 22% 8%, rgb(255 226 145 / .2), transparent 28%),
-    linear-gradient(180deg, #547188 0 22%, #3D5363 22% 31%, #6B503A 31% 100%) !important;
-}
-[data-skin="mine"] .tube {
-  border-color: transparent;
-  border-bottom: .35rem solid #2B2118;
-  border-radius: 0;
-  background: linear-gradient(90deg, rgb(0 0 0 / .12), transparent 35% 65%, rgb(0 0 0 / .18));
-  padding: 0 1px 5px;
-}
-[data-skin="mine"] .item {
-  padding: 0;
-  filter: drop-shadow(0 4px 2px rgb(26 20 16 / .38));
-}
-[data-skin="mine"] .item svg { scale: .96; overflow: visible; image-rendering: pixelated; }
-[data-skin="mine"] .tube.done { box-shadow: 0 0 0 3px #8FCC5E, 0 0 16px 4px rgb(143 204 94 / .55); }
-
-[data-skin="dash"] .item { padding: 0; }
-[data-skin="dash"] .item svg {
-  scale: .92;
-  filter: drop-shadow(0 0 5px rgb(62 240 208 / .38));
-}
 
 /* the selected lift and done cues stay identical across skins on purpose:
    the READING of the board never changes, only its world */

--- a/src/app.css
+++ b/src/app.css
@@ -241,11 +241,9 @@ h1 {
 }
 .item.hid svg { opacity: .9; }
 
-/* ===== skins: the container + the item backing, picked in LOOKS =====
-   the default rules above ARE the classic (tubes) skin; each skin below
-   overrides only what its metaphor changes. items keep the theme's art as
-   the face, and every skin's job is to make that face sit on an OBJECT:
-   light from the upper left, a shaded underside, a real shadow. */
+/* ===== skins: total board conversions, picked in LOOKS =====
+   the default rules above ARE Classic. conversion skins provide their own
+   twelve pieces; their css owns only the furniture and presentation. */
 
 /* an item mid-flight rides above every container on the board */
 .item.flying { position: relative; z-index: 30; }
@@ -539,8 +537,44 @@ h1 {
 [data-skin="kawaii"] .item svg { position: relative; scale: .74; }
 [data-skin="kawaii"] .tube.sel { box-shadow: 0 .35rem 0 #E8A9C4; }
 
+/* v1 total conversions. The earlier costume selectors stay harmless while
+   the branch is in flight; these later rules remove their shared backings so
+   each conversion's SVG is the complete piece, not a theme face on a prop. */
+[data-skin="bolts"] .item::before,
+[data-skin="bolts"] .item::after,
+[data-skin="dash"] .item::before,
+[data-skin="dash"] .item::after { content: none; }
+
+[data-skin="bolts"] .item { padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
+[data-skin="bolts"] .item svg { scale: .96; }
+
+#board[data-skin="mine"] {
+  background:
+    radial-gradient(circle at 22% 8%, rgb(255 226 145 / .2), transparent 28%),
+    linear-gradient(180deg, #547188 0 22%, #3D5363 22% 31%, #6B503A 31% 100%) !important;
+}
+[data-skin="mine"] .tube {
+  border-color: transparent;
+  border-bottom: .35rem solid #2B2118;
+  border-radius: 0;
+  background: linear-gradient(90deg, rgb(0 0 0 / .12), transparent 35% 65%, rgb(0 0 0 / .18));
+  padding: 0 1px 5px;
+}
+[data-skin="mine"] .item {
+  padding: 0;
+  filter: drop-shadow(0 4px 2px rgb(26 20 16 / .38));
+}
+[data-skin="mine"] .item svg { scale: .96; overflow: visible; image-rendering: pixelated; }
+[data-skin="mine"] .tube.done { box-shadow: 0 0 0 3px #8FCC5E, 0 0 16px 4px rgb(143 204 94 / .55); }
+
+[data-skin="dash"] .item { padding: 0; }
+[data-skin="dash"] .item svg {
+  scale: .92;
+  filter: drop-shadow(0 0 5px rgb(62 240 208 / .38));
+}
+
 /* the selected lift and done cues stay identical across skins on purpose:
-   the READING of the board never changes, only its costume */
+   the READING of the board never changes, only its world */
 
 .tube.shake { animation: shake .3s ease; }
 @keyframes shake {

--- a/src/lib/engine/skinart/bolts.js
+++ b/src/lib/engine/skinart/bolts.js
@@ -62,7 +62,7 @@ function nut(key, face, lit, shade, mark) {
     // the crown: a flatter inner hex catching the light
     `<path d="${INNER}" fill="url(#${g}-c)" stroke="${shade}" stroke-width="1.5" stroke-linejoin="round" opacity=".95"/>` +
     // the stamped mark, engraved into the crown
-    `<path d="${MARKS[mark]}" fill="${shade}" opacity=".85" transform="translate(0 -13) scale(.72) translate(12.5 12.5)"/>` +
+    `<path d="${MARKS[mark]}" fill="#1E1B19" opacity=".8" transform="translate(0 -12.5) scale(.95) translate(1.7 1.7)"/>` +
     // the threaded bore
     `<circle cx="32" cy="36" r="9.5" fill="url(#${g}-b)" stroke="#1E1B19" stroke-width="1.5"/>` +
     `<circle cx="32" cy="36" r="6.5" fill="none" stroke="#8C847C" stroke-width="1.2" stroke-dasharray="2.2 1.6" opacity=".8"/>` +

--- a/src/lib/engine/skinart/bolts.js
+++ b/src/lib/engine/skinart/bolts.js
@@ -1,0 +1,84 @@
+// nuts & bolts pieces: twelve anodised hex nuts, face on, lit from the upper
+// left. the nut IS the piece (no theme face on top): colour carries identity,
+// and a small stamped mark on the crown carries it again for anyone who does
+// not read colour. drawn for a viewBox of 0 0 64 64.
+//
+// every piece module in skinart/ exports the same shape:
+//   { pieces: [12 x { key, color, svg }], hidden: svg }
+
+const HEX = 'M32 4 L56 18 L56 46 L32 60 L8 46 L8 18 Z'
+const INNER = 'M32 11 L50 21.5 L50 42.5 L32 53 L14 42.5 L14 21.5 Z'
+
+// the twelve stamped marks, each a tiny engraving centred at (32,32), drawn
+// in a darker shade of the nut so it reads as machined rather than painted
+const MARKS = {
+  dot: 'M32 32 m-3 0 a3 3 0 1 0 6 0 a3 3 0 1 0 -6 0',
+  bar: 'M25 30 h14 v4 h-14 z',
+  plus: 'M30 25 h4 v5 h5 v4 h-5 v5 h-4 v-5 h-5 v-4 h5 z',
+  cross: 'M26 26 l3 -0.2 l3 3.2 l3 -3.2 l3 0.2 l-4.5 6 l4.5 6 l-3 0.2 l-3 -3.2 l-3 3.2 l-3 -0.2 l4.5 -6 z',
+  tri: 'M32 25 l7 12 h-14 z',
+  ring: 'M32 32 m-6 0 a6 6 0 1 0 12 0 a6 6 0 1 0 -12 0 z M32 32 m-3 0 a3 3 0 1 1 6 0 a3 3 0 1 1 -6 0 z',
+  square: 'M27 27 h10 v10 h-10 z',
+  star: 'M32 24 l2.4 5.2 l5.6 .6 l-4.2 3.8 l1.2 5.6 l-5 -2.9 l-5 2.9 l1.2 -5.6 l-4.2 -3.8 l5.6 -.6 z',
+  diamond: 'M32 25 l7 7 l-7 7 l-7 -7 z',
+  dots: 'M27 32 m-2.6 0 a2.6 2.6 0 1 0 5.2 0 a2.6 2.6 0 1 0 -5.2 0 M37 32 m-2.6 0 a2.6 2.6 0 1 0 5.2 0 a2.6 2.6 0 1 0 -5.2 0',
+  chevron: 'M25 30 l7 -6 l7 6 l-2.6 2.6 l-4.4 -3.8 l-4.4 3.8 z M25 37 l7 -6 l7 6 l-2.6 2.6 l-4.4 -3.8 l-4.4 3.8 z',
+  wave: 'M24 33 q4 -7 8 0 t8 0 l0 3.5 q-4 7 -8 0 t-8 0 z',
+}
+
+// colour triples: face, lit edge, shadow edge. the twelve read apart on a
+// phone in sunlight, and no two share a hue family.
+const NUTS = [
+  ['red', '#E5484D', '#FF8A8E', '#8E2226', 'dot'],
+  ['blue', '#3B82F6', '#8DB8FF', '#1E3F8A', 'bar'],
+  ['gold', '#F0B429', '#FFE08A', '#8C6410', 'plus'],
+  ['green', '#46A758', '#93D9A0', '#1F5A2B', 'cross'],
+  ['violet', '#8E4EC6', '#C9A0EA', '#4A2470', 'tri'],
+  ['orange', '#F76B15', '#FFA96B', '#8A3A08', 'ring'],
+  ['teal', '#12A594', '#7DD9CD', '#085C52', 'square'],
+  ['pink', '#E93D82', '#FF9CC4', '#821E47', 'star'],
+  ['brown', '#A0704A', '#D4AC88', '#5A3B24', 'diamond'],
+  ['sky', '#5BB8F5', '#B3E1FF', '#2A6A96', 'dots'],
+  ['lime', '#9BC53D', '#D3EB8F', '#557020', 'chevron'],
+  ['plum', '#5C3B8C', '#A98AD1', '#2C1A48', 'wave'],
+]
+
+function nut(key, face, lit, shade, mark) {
+  const g = `bolt-${key}`
+  return (
+    `<defs>` +
+    `<linearGradient id="${g}-f" x1="0" y1="0" x2="1" y2="1">` +
+    `<stop offset="0" stop-color="${lit}"/><stop offset=".45" stop-color="${face}"/><stop offset="1" stop-color="${shade}"/>` +
+    `</linearGradient>` +
+    `<linearGradient id="${g}-c" x1="0" y1="0" x2="1" y2="1">` +
+    `<stop offset="0" stop-color="${face}"/><stop offset="1" stop-color="${lit}"/>` +
+    `</linearGradient>` +
+    `<radialGradient id="${g}-b" cx=".4" cy=".35" r=".7">` +
+    `<stop offset="0" stop-color="#6E665F"/><stop offset=".6" stop-color="#3A3430"/><stop offset="1" stop-color="#1E1B19"/>` +
+    `</radialGradient>` +
+    `</defs>` +
+    // the outer hex body, bevelled by the diagonal gradient
+    `<path d="${HEX}" fill="url(#${g}-f)" stroke="#2A2220" stroke-width="2.5" stroke-linejoin="round"/>` +
+    // the crown: a flatter inner hex catching the light
+    `<path d="${INNER}" fill="url(#${g}-c)" stroke="${shade}" stroke-width="1.5" stroke-linejoin="round" opacity=".95"/>` +
+    // the stamped mark, engraved into the crown
+    `<path d="${MARKS[mark]}" fill="${shade}" opacity=".85" transform="translate(0 -13) scale(.72) translate(12.5 12.5)"/>` +
+    // the threaded bore
+    `<circle cx="32" cy="36" r="9.5" fill="url(#${g}-b)" stroke="#1E1B19" stroke-width="1.5"/>` +
+    `<circle cx="32" cy="36" r="6.5" fill="none" stroke="#8C847C" stroke-width="1.2" stroke-dasharray="2.2 1.6" opacity=".8"/>` +
+    // one specular glint on the upper-left flat
+    `<path d="M12 20 L30 9 L30 12 L14 22 Z" fill="#fff" opacity=".45"/>`
+  )
+}
+
+export default {
+  pieces: NUTS.map(([key, face, lit, shade, mark]) => ({ key: `${key} nut`, color: face, svg: nut(key, face, lit, shade, mark) })),
+  // a mystery nut: dull unfinished steel with a question stamp
+  hidden:
+    `<defs><linearGradient id="bolt-hid" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#D9D3CC"/><stop offset=".5" stop-color="#A39B93"/><stop offset="1" stop-color="#5E5751"/></linearGradient></defs>` +
+    `<path d="${HEX}" fill="url(#bolt-hid)" stroke="#2A2220" stroke-width="2.5" stroke-linejoin="round"/>` +
+    `<path d="${INNER}" fill="#B5ADA5" stroke="#5E5751" stroke-width="1.5" stroke-linejoin="round"/>` +
+    `<path d="M27 25 Q27 19 32 19 Q37 19 37 24 Q37 28 33 29.5 L33 32" stroke="#4A433D" stroke-width="3" fill="none" stroke-linecap="round"/>` +
+    `<circle cx="33" cy="36.5" r="1.8" fill="#4A433D"/>` +
+    `<circle cx="32" cy="45" r="5" fill="#3A3430" stroke="#1E1B19" stroke-width="1.5"/>`,
+}

--- a/src/lib/engine/skinart/dash.js
+++ b/src/lib/engine/skinart/dash.js
@@ -1,0 +1,103 @@
+// dash pieces: twelve player icons from a geometric rhythm-runner, bold black
+// outline, two flat neon colours, a face that is all attitude. the forms
+// differ (cube, ball, ship, ufo, wave) so silhouettes sort as well as colours
+// do, and each form carries its own move verb (a cube flips, a ball rolls, a
+// ship flies, a ufo hovers, a wave zigs). an aesthetic tribute: the look is
+// the homage, every design here is ours. viewBox 0 0 64 64.
+//
+// exports { pieces: [12 x { key, color, svg, verb }], hidden: svg }
+
+const INK = '#0B0B14'
+const SW = 3.6
+
+function cube(key, a, b, design) {
+  const eyes = {
+    // each design: a different face and inner geometry so two cubes never twin
+    classic: `<rect x="20" y="22" width="9" height="12" fill="${INK}"/><rect x="35" y="22" width="9" height="12" fill="${INK}"/><rect x="22" y="24" width="4" height="5" fill="#fff"/><rect x="37" y="24" width="4" height="5" fill="#fff"/><rect x="24" y="40" width="16" height="4" fill="${INK}"/>`,
+    smirk: `<rect x="18" y="20" width="12" height="9" fill="${b}" stroke="${INK}" stroke-width="2.6"/><rect x="34" y="20" width="12" height="9" fill="${b}" stroke="${INK}" stroke-width="2.6"/><rect x="21" y="23" width="5" height="4" fill="${INK}"/><rect x="37" y="23" width="5" height="4" fill="${INK}"/><path d="M22 41 L34 41 L42 36" stroke="${INK}" stroke-width="3.4" fill="none" stroke-linecap="round"/>`,
+    angry: `<path d="M17 18 L30 24 L30 32 L17 32 Z" fill="${INK}"/><path d="M47 18 L34 24 L34 32 L47 32 Z" fill="${INK}"/><rect x="24" y="26" width="4" height="4" fill="#fff"/><rect x="36" y="26" width="4" height="4" fill="#fff"/><rect x="20" y="40" width="24" height="5" fill="${INK}"/><rect x="24" y="40" width="4" height="5" fill="#fff"/><rect x="36" y="40" width="4" height="5" fill="#fff"/>`,
+    visor: `<rect x="16" y="20" width="32" height="12" rx="2" fill="${INK}"/><rect x="19" y="23" width="26" height="4" fill="${b}"/><rect x="26" y="40" width="12" height="4" fill="${INK}"/>`,
+    wide: `<circle cx="24" cy="28" r="7" fill="#fff" stroke="${INK}" stroke-width="2.6"/><circle cx="40" cy="28" r="7" fill="#fff" stroke="${INK}" stroke-width="2.6"/><circle cx="26" cy="29" r="3" fill="${INK}"/><circle cx="42" cy="29" r="3" fill="${INK}"/><path d="M22 41 Q32 48 42 41" stroke="${INK}" stroke-width="3.4" fill="none" stroke-linecap="round"/>`,
+  }
+  return {
+    key: `${key} cube`, color: a, verb: 'flip',
+    svg:
+      `<rect x="10" y="10" width="44" height="44" rx="4" fill="${a}" stroke="${INK}" stroke-width="${SW}"/>` +
+      `<rect x="15" y="15" width="34" height="34" rx="2" fill="none" stroke="${b}" stroke-width="3"/>` +
+      eyes[design],
+  }
+}
+
+function ball(key, a, b, design) {
+  const inner = design === 'split'
+    ? `<path d="M32 10 A22 22 0 0 1 32 54 Z" fill="${b}"/>`
+    : `<circle cx="32" cy="32" r="12" fill="${b}"/><circle cx="32" cy="32" r="6" fill="${a}"/>`
+  return {
+    key: `${key} ball`, color: a, verb: 'roll',
+    svg:
+      `<circle cx="32" cy="32" r="22" fill="${a}"/>` + inner +
+      `<circle cx="32" cy="32" r="22" fill="none" stroke="${INK}" stroke-width="${SW}"/>` +
+      `<rect x="23" y="25" width="6" height="8" fill="${INK}"/><rect x="35" y="25" width="6" height="8" fill="${INK}"/>` +
+      `<path d="M26 41 L38 41" stroke="${INK}" stroke-width="3.2" stroke-linecap="round"/>`,
+  }
+}
+
+function ship(key, a, b, design) {
+  const fin = design === 'tall'
+    ? `<path d="M18 36 L18 14 L30 30 Z" fill="${b}" stroke="${INK}" stroke-width="3" stroke-linejoin="round"/>`
+    : `<path d="M14 34 L22 18 L32 30 Z" fill="${b}" stroke="${INK}" stroke-width="3" stroke-linejoin="round"/>`
+  return {
+    key: `${key} ship`, color: a, verb: 'fly',
+    svg:
+      fin +
+      `<path d="M8 38 L44 30 L58 38 L50 50 L14 50 Z" fill="${a}" stroke="${INK}" stroke-width="${SW}" stroke-linejoin="round"/>` +
+      `<circle cx="40" cy="40" r="5" fill="#fff" stroke="${INK}" stroke-width="2.4"/><circle cx="41.5" cy="40.5" r="2" fill="${INK}"/>` +
+      `<rect x="10" y="46" width="30" height="3" fill="${INK}" opacity=".45"/>`,
+  }
+}
+
+function ufo(key, a, b) {
+  return {
+    key: `${key} ufo`, color: a, verb: 'hover',
+    svg:
+      `<path d="M20 34 A12 14 0 0 1 44 34 Z" fill="${b}" stroke="${INK}" stroke-width="3"/>` +
+      `<ellipse cx="32" cy="38" rx="26" ry="9" fill="${a}" stroke="${INK}" stroke-width="${SW}"/>` +
+      `<circle cx="16" cy="38" r="2.6" fill="#fff"/><circle cx="32" cy="41" r="2.6" fill="#fff"/><circle cx="48" cy="38" r="2.6" fill="#fff"/>` +
+      `<rect x="27" y="24" width="4" height="6" fill="${INK}"/><rect x="34" y="24" width="4" height="6" fill="${INK}"/>`,
+  }
+}
+
+function wave(key, a, b) {
+  return {
+    key: `${key} wave`, color: a, verb: 'zig',
+    svg:
+      `<path d="M10 32 L38 14 L38 26 L56 32 L38 38 L38 50 Z" fill="${a}" stroke="${INK}" stroke-width="${SW}" stroke-linejoin="round"/>` +
+      `<path d="M22 32 L38 22 L38 42 Z" fill="${b}"/>` +
+      `<circle cx="42" cy="32" r="3" fill="${INK}"/>`,
+  }
+}
+
+const pieces = [
+  cube('lime', '#7CFF3F', '#0B0B14', 'classic'),
+  cube('magenta', '#FF3FD8', '#33062A', 'smirk'),
+  cube('cyan', '#3FF0FF', '#083A40', 'angry'),
+  cube('orange', '#FF8A00', '#5A2E00', 'visor'),
+  cube('violet', '#A24BFF', '#2A0F4A', 'wide'),
+  ball('yellow', '#FFE63F', '#7A6A00', 'split'),
+  ball('red', '#FF3B3B', '#5C0A0A', 'core'),
+  ship('blue', '#3F7BFF', '#0E2B70', 'tall'),
+  ship('white', '#F4F4FF', '#8A8AA8', 'low'),
+  ufo('mint', '#3FFFB0', '#0C5A3B'),
+  ufo('pink', '#FF7FD2', '#7A1E5A'),
+  wave('gold', '#FFC53F', '#6B4A00'),
+]
+
+export default {
+  pieces,
+  // a mystery icon: a locked dark cube with the question mark lit up
+  hidden:
+    `<rect x="10" y="10" width="44" height="44" rx="4" fill="#1B1B2E" stroke="${INK}" stroke-width="${SW}"/>` +
+    `<rect x="15" y="15" width="34" height="34" rx="2" fill="none" stroke="#3EF0D0" stroke-width="2.5" opacity=".6"/>` +
+    `<path d="M26 26 Q26 19 32 19 Q38 19 38 25 Q38 30 33 31.5 L33 35" stroke="#3EF0D0" stroke-width="3.4" fill="none" stroke-linecap="round"/>` +
+    `<circle cx="33" cy="41" r="2.2" fill="#3EF0D0"/>`,
+}

--- a/src/lib/engine/skinart/mine.js
+++ b/src/lib/engine/skinart/mine.js
@@ -1,0 +1,279 @@
+// mine pieces: twelve blocks from a dug world, drawn as small 2.5d cubes with
+// a pixel texture on each face. lit from the upper left: top face brightest,
+// front face true colour, right face in shadow. an aesthetic tribute to the
+// blocky mining genre: the look is the homage, every name and pixel is ours.
+// viewBox 0 0 64 64.
+//
+// exports { pieces: [12 x { key, color, svg }], hidden: svg }
+
+// cube geometry. the front face is a 40x40 square; top and right faces are
+// parallelograms drawn in their own (u,v) space through a matrix so that
+// pixel rects land on the slanted face without hand-computing corners.
+//   front: x 12..52, y 20..60
+//   top:   (u,v) -> (12 + u + v, 20 - v), u 0..40, v 0..12
+//   right: (u,v) -> (52 + v, 20 + u - v), u 0..40, v 0..12
+const TOP = 'matrix(1 0 1 -1 12 20)'
+const RIGHT = 'matrix(0 1 1 -1 52 20)'
+
+// an 8x8 pixel grid on a 40-unit face: each cell is 5 units
+const CELL = 5
+
+// draws a face from a pattern string: 8 rows of 8 chars, each char a key
+// into the palette. '.' leaves the base colour showing.
+function face(pattern, palette, base) {
+  let out = `<rect x="0" y="0" width="40" height="40" fill="${base}"/>`
+  const rows = pattern.trim().split('\n').map(r => r.trim())
+  rows.forEach((row, y) => {
+    for (let x = 0; x < 8; x++) {
+      const ch = row[x]
+      if (ch && ch !== '.' && palette[ch]) out += `<rect x="${x * CELL}" y="${y * CELL}" width="${CELL}" height="${CELL}" fill="${palette[ch]}"/>`
+    }
+  })
+  return out
+}
+
+// a slanted face: 8 columns by 2-ish rows of the same pattern language, drawn
+// in the face's (u,v) space; only the first 3 rows of the pattern are used
+function slant(pattern, palette, base, matrix) {
+  let out = `<g transform="${matrix}"><rect x="0" y="0" width="40" height="12" fill="${base}"/>`
+  const rows = pattern.trim().split('\n').map(r => r.trim()).slice(0, 3)
+  rows.forEach((row, v) => {
+    for (let x = 0; x < 8; x++) {
+      const ch = row[x]
+      if (ch && ch !== '.' && palette[ch]) out += `<rect x="${x * CELL}" y="${v * 4}" width="${CELL}" height="4" fill="${palette[ch]}"/>`
+    }
+  })
+  return out + '</g>'
+}
+
+const OUTLINE = '#1A1410'
+
+function cube({ frontBase, frontPattern, topBase, topPattern, rightBase, rightPattern, palette }) {
+  return (
+    `<g transform="translate(0 2)">` +
+    slant(topPattern ?? frontPattern, palette, topBase, TOP) +
+    slant(rightPattern ?? frontPattern, palette, rightBase, RIGHT) +
+    `<g transform="translate(12 20)">${face(frontPattern, palette, frontBase)}</g>` +
+    // the shading that sells the corner: a soft dark wash on the right face,
+    // a light wash on the top, and one crisp outline around the whole block
+    `<path d="M52 20 L64 8 L64 48 L52 60 Z" fill="#000" opacity=".28"/>` +
+    `<path d="M12 20 L24 8 L64 8 L52 20 Z" fill="#fff" opacity=".22"/>` +
+    `<path d="M12 20 L24 8 L64 8 L64 48 L52 60 L12 60 Z" fill="none" stroke="${OUTLINE}" stroke-width="2" stroke-linejoin="round"/>` +
+    `<path d="M12 20 L52 20 L52 60 M52 20 L64 8" fill="none" stroke="${OUTLINE}" stroke-width="1.4" opacity=".7"/>` +
+    `</g>`
+  )
+}
+
+// texture recipes. stone-family blocks share the same base so the ores read
+// as "stone with something in it", the way a real seam does.
+const STONE = { base: '#8E8E8E', light: '#A7A7A7', dark: '#6F6F6F' }
+const stoneSpeck = `
+  ..L.....
+  .....D..
+  D.......
+  ....L...
+  ..D.....
+  ......D.
+  .L......
+  ....D...`
+
+function ore(name, color, glint, shape) {
+  // shape: the pixel footprint of one ore chunk, repeated at four spots
+  const chunks = {
+    blob: `
+      ........
+      .OO...O.
+      .OGO..OO
+      ..O.....
+      .....OO.
+      O...OGO.
+      OG...O..
+      .O......`,
+    round: `
+      ........
+      ..OO....
+      .OGGO...
+      ..OO..O.
+      .....OGO
+      .OO...O.
+      OGGO....
+      .OO.....`,
+    square: `
+      ........
+      .OO..OO.
+      .OG..GO.
+      ........
+      ...OO...
+      ...GO...
+      .OO..OO.
+      .GO..OG.`,
+    rhomb: `
+      ...O....
+      ..OGO...
+      ...O..O.
+      .....OGO
+      .O....O.
+      OGO.....
+      .O...O..
+      ....OGO.`,
+    cross: `
+      ..O.....
+      .OGO..O.
+      ..O..OGO
+      ......O.
+      ..O.....
+      .OGO..O.
+      ..O..OGO
+      ......O.`,
+  }
+  return {
+    key: `${name} ore`,
+    color,
+    svg: cube({
+      frontBase: STONE.base, topBase: STONE.light, rightBase: STONE.dark,
+      frontPattern: chunks[shape], topPattern: stoneSpeck, rightPattern: stoneSpeck,
+      palette: { O: color, G: glint, L: STONE.light, D: STONE.dark },
+    }),
+  }
+}
+
+const pieces = [
+  {
+    key: 'grass block', color: '#6FA644',
+    svg: cube({
+      frontBase: '#8A6142', topBase: '#7FBF4E', rightBase: '#6E4C33',
+      frontPattern: `
+        GGGGGGGG
+        G.GGG.GG
+        ..D.....
+        ....D...
+        .D......
+        ......D.
+        ..D.....
+        D....D..`,
+      topPattern: `
+        .g...g..
+        ...g...g
+        g...g...`,
+      rightPattern: `
+        GGGGGGGG
+        .G..G.G.
+        ....D...`,
+      palette: { G: '#7FBF4E', g: '#98D45E', D: '#6E4C33' },
+    }),
+  },
+  {
+    key: 'dirt block', color: '#8A6142',
+    svg: cube({
+      frontBase: '#8A6142', topBase: '#A3764F', rightBase: '#6E4C33',
+      frontPattern: `
+        ..D.....
+        .....L..
+        D...D...
+        ...L....
+        .D......
+        ....D.L.
+        L.......
+        ...D....`,
+      palette: { D: '#6E4C33', L: '#A3764F' },
+    }),
+  },
+  {
+    key: 'stone block', color: '#8E8E8E',
+    svg: cube({ frontBase: STONE.base, topBase: STONE.light, rightBase: STONE.dark, frontPattern: stoneSpeck, palette: { L: STONE.light, D: STONE.dark } }),
+  },
+  {
+    key: 'cobble block', color: '#7A7F86',
+    svg: cube({
+      frontBase: '#7A7F86', topBase: '#979CA3', rightBase: '#5C6167',
+      frontPattern: `
+        LLL.DLL.
+        L..D.L.D
+        .DD..DD.
+        L..LL..L
+        .DD..D.L
+        LL.D.LL.
+        ..DD..D.
+        LL..LL..`,
+      palette: { L: '#979CA3', D: '#4F545A' },
+    }),
+  },
+  {
+    key: 'oak log', color: '#6B4A2B',
+    svg: cube({
+      frontBase: '#6B4A2B', topBase: '#C9A46B', rightBase: '#523821',
+      frontPattern: `
+        D.L.D.L.
+        D.L.D.L.
+        D.L.D.L.
+        D.L.D.L.
+        D.L.D.L.
+        D.L.D.L.
+        D.L.D.L.
+        D.L.D.L.`,
+      topPattern: `
+        .rrrrrr.
+        .r....r.
+        .rrrrrr.`,
+      palette: { D: '#4A3118', L: '#86603A', r: '#9C7A4C' },
+    }),
+  },
+  {
+    key: 'plank block', color: '#C29A5B',
+    svg: cube({
+      frontBase: '#C29A5B', topBase: '#DDB877', rightBase: '#9C7A44',
+      frontPattern: `
+        ........
+        DDDDDDDD
+        ....D...
+        DDDDDDDD
+        ........
+        DDDDDDDD
+        ..D.....
+        DDDDDDDD`,
+      palette: { D: '#8A6A3A' },
+    }),
+  },
+  {
+    key: 'sand block', color: '#E6D8A8',
+    svg: cube({
+      frontBase: '#E6D8A8', topBase: '#F4EAC2', rightBase: '#C4B486',
+      frontPattern: `
+        ...D....
+        L.....D.
+        ....L...
+        .D......
+        ......L.
+        ..L.D...
+        D.......
+        .....D..`,
+      palette: { D: '#C4B486', L: '#FBF3D6' },
+    }),
+  },
+  ore('coal', '#2B2B2B', '#4A4A4A', 'blob'),
+  ore('iron', '#D9A878', '#F1CBA5', 'round'),
+  ore('gold', '#F5C542', '#FFE795', 'square'),
+  ore('diamond', '#5FE3E0', '#BDFFFC', 'rhomb'),
+  ore('redstone', '#E0342C', '#FF7A72', 'cross'),
+]
+
+export default {
+  pieces,
+  // a mystery block: unbreakable-looking dark bedrock with a question mark
+  hidden:
+    cube({
+      frontBase: '#3A3A3A', topBase: '#5A5A5A', rightBase: '#242424',
+      frontPattern: `
+        L..D..L.
+        .DD..D..
+        ..L...DD
+        D...D...
+        ..D...L.
+        LD..D...
+        ...L..D.
+        .D...D..`,
+      palette: { L: '#5A5A5A', D: '#1C1C1C' },
+    }) +
+    `<path d="M27 30 Q27 24 32 24 Q37 24 37 29 Q37 33 33 34.5 L33 37" stroke="#E8E8E8" stroke-width="3.2" fill="none" stroke-linecap="round"/>` +
+    `<circle cx="33" cy="42" r="2" fill="#E8E8E8"/>`,
+}

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -1,78 +1,65 @@
-// skins: how the board LOOKS and how a move MOVES, orthogonal to themes.
-// a theme picks the twelve faces (art/); a skin picks the container those
-// faces live in, the flight that carries them between containers, and the
-// material they sound like when they land.
+// skins: total conversions of the board, orthogonal to the engine. a skin
+// owns what the pieces ARE (its own twelve, or the theme's art for classic),
+// what the containers look like, how a move travels, what it sounds like.
+// the engine, the levels, and the scoring never know which skin is on.
 //
-// each skin styles the board via [data-skin] rules in app.css. motion is a
-// three-beat flight the Board choreographs with the web animations api:
-// lift out of the source, arc across, then the skin's own landing verb.
-//
-//   seconds  whole flight for one item
-//   lift     arc peak above the higher tube mouth, in item-sides
-//   spin     degrees turned over the flight (multiples of 360 land upright;
-//            the screw lands at -720 so the hex flats visibly wind down)
-//   ease     easing for the landing beat
-//   stagger  per-item delay when a run of items convoys over
-//   land     landing verb: also picks the particle burst and sound family
-//            'drop' | 'screw' | 'slide' | 'bounce' | 'zip' | 'float'
-//   sound    material palette in sounds.js: 'glass' | 'metal' | 'wood' |
-//            'stone' | 'neon' | 'pop'
+// each skin:
+//   pieces   twelve { key, color, svg, verb? } from skinart/, or absent for a
+//            theme-driven skin (classic shows the world's art faces)
+//   hidden   the mystery piece's svg (absent = the shared question mark)
+//   motion   the flight the Board plays with the web animations api:
+//     seconds  whole trip for one item
+//     lift     arc peak above the higher tube mouth, in item-sides
+//     spin     degrees turned over the trip (full turns land upright)
+//     stagger  per-item delay when a run of items convoys over
+//     land     default verb (a piece may override with its own `verb`):
+//              drop | screw | breakpop | flip | roll | fly | hover | zig
+//   sound    material palette in sounds.js: metal | stone | neon | pop
+//   preview  inner svg for the LOOKS card, viewBox 0 0 64 64
+import bolts from './skinart/bolts.js'
+import mine from './skinart/mine.js'
+import dash from './skinart/dash.js'
+
+// a LOOKS card: two of the skin's own pieces stacked, so the card is the skin
+const stack = (a, b) =>
+  `<g transform="translate(14 30) scale(.56)">${a}</g><g transform="translate(14 -2) scale(.56)">${b}</g>`
+
 export const SKINS = [
-  {
-    key: 'glass',
-    title: 'Glass',
-    motion: { seconds: .38, lift: 1.1, spin: 0, ease: 'cubic-bezier(.3,1.25,.5,1)', stagger: .055, land: 'drop' },
-    sound: 'glass',
-    preview: '<defs><linearGradient id="pg" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#fff" stop-opacity=".9"/><stop offset=".35" stop-color="#fff" stop-opacity=".25"/><stop offset="1" stop-color="#cfe3ef" stop-opacity=".5"/></linearGradient></defs><rect x="20" y="8" width="24" height="48" rx="10" fill="url(#pg)" stroke="#3D3230" stroke-width="3"/><rect x="24" y="12" width="5" height="38" rx="2.5" fill="#fff" opacity=".8"/><circle cx="32" cy="46" r="7" fill="#E5484D"/><circle cx="32" cy="31" r="7" fill="#4FA3D1"/>',
-  },
   {
     key: 'bolts',
     title: 'Nuts & Bolts',
-    motion: { seconds: .52, lift: 1.25, spin: -720, ease: 'cubic-bezier(.45,.05,.55,.95)', stagger: .07, land: 'screw' },
+    pieces: bolts.pieces,
+    hidden: bolts.hidden,
+    motion: { seconds: .56, lift: 1.25, spin: -720, stagger: .08, land: 'screw' },
     sound: 'metal',
-    preview: '<defs><linearGradient id="pb" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#EFEAE3"/><stop offset=".5" stop-color="#B9AFA6"/><stop offset="1" stop-color="#8F857C"/></linearGradient></defs><rect x="29" y="8" width="6" height="48" fill="url(#pb)" stroke="#3D3230" stroke-width="2.4"/><path d="M22 44 L27 40 L37 40 L42 44 L42 52 L37 56 L27 56 L22 52 Z" fill="url(#pb)" stroke="#3D3230" stroke-width="2.6"/><path d="M22 26 L27 22 L37 22 L42 26 L42 34 L37 38 L27 38 L22 34 Z" fill="url(#pb)" stroke="#3D3230" stroke-width="2.6"/>',
+    preview:
+      `<rect x="29" y="2" width="6" height="60" fill="#B9AFA6" stroke="#2A2220" stroke-width="2"/>` +
+      stack(bolts.pieces[0].svg, bolts.pieces[1].svg),
   },
   {
-    key: 'beads',
-    title: 'Beads & Sticks',
-    motion: { seconds: .34, lift: 1.15, spin: 0, ease: 'cubic-bezier(.25,1.35,.45,1)', stagger: .05, land: 'slide' },
-    sound: 'wood',
-    preview: '<rect x="30" y="6" width="4" height="50" rx="2" fill="#A98F71" stroke="#3D3230" stroke-width="2"/><circle cx="32" cy="47" r="8" fill="#79B84C" stroke="#3D3230" stroke-width="2.6"/><circle cx="32" cy="30" r="8" fill="#F0C33C" stroke="#3D3230" stroke-width="2.6"/>',
-  },
-  {
-    key: 'blocks',
-    title: 'Block Stacks',
-    motion: { seconds: .36, lift: 1.3, spin: 360, ease: 'cubic-bezier(.34,1.45,.6,1)', stagger: .06, land: 'bounce' },
-    sound: 'wood',
-    preview: '<rect x="20" y="38" width="24" height="18" fill="#79B84C" stroke="#3D3230" stroke-width="3"/><rect x="20" y="18" width="24" height="18" fill="#B98A5A" stroke="#3D3230" stroke-width="3"/>',
-  },
-  // the three below are aesthetic tributes, deliberately NOT the trademarks:
-  // the look is the homage, the name stays ours.
-  {
-    key: 'voxel',
-    title: 'Voxel Mine',
-    motion: { seconds: .34, lift: 1.2, spin: 0, ease: 'cubic-bezier(.5,0,.8,.6)', stagger: .06, land: 'bounce' },
+    key: 'mine',
+    title: 'Block Mine',
+    pieces: mine.pieces,
+    hidden: mine.hidden,
+    motion: { seconds: .62, lift: 0, spin: 0, stagger: .14, land: 'breakpop' },
     sound: 'stone',
-    preview: '<g transform="translate(4 2)"><path d="M18 40 L18 58 L42 58 L42 40 Z" fill="#8A6142" stroke="#3D3230" stroke-width="3"/><path d="M18 40 L26 33 L50 33 L42 40 Z" fill="#6FA644" stroke="#3D3230" stroke-width="3"/><path d="M42 40 L50 33 L50 51 L42 58 Z" fill="#5C3F2B" stroke="#3D3230" stroke-width="3"/><path d="M18 16 L18 34 L42 34 L42 16 Z" fill="#8A6142" stroke="#3D3230" stroke-width="3" transform="translate(0 -12)"/><path d="M18 16 L26 9 L50 9 L42 16 Z" fill="#6FA644" stroke="#3D3230" stroke-width="3" transform="translate(0 -12)"/><path d="M42 16 L50 9 L50 27 L42 34 Z" fill="#5C3F2B" stroke="#3D3230" stroke-width="3" transform="translate(0 -12)"/></g>',
+    preview: stack(mine.pieces[1].svg, mine.pieces[0].svg),
   },
   {
     key: 'dash',
     title: 'Neon Dash',
-    motion: { seconds: .26, lift: .9, spin: -360, ease: 'cubic-bezier(.5,0,.2,1)', stagger: .04, land: 'zip' },
+    pieces: dash.pieces,
+    hidden: dash.hidden,
+    motion: { seconds: .44, lift: 1, spin: 360, stagger: .06, land: 'flip' },
     sound: 'neon',
-    preview: '<rect x="6" y="6" width="52" height="52" rx="6" fill="#141A2E"/><rect x="20" y="34" width="20" height="20" rx="3" fill="#1B2340" stroke="#3EF0D0" stroke-width="3"/><rect x="20" y="11" width="20" height="20" rx="3" fill="#1B2340" stroke="#FF4FD8" stroke-width="3"/>',
-  },
-  {
-    key: 'kawaii',
-    title: 'Kawaii Pop',
-    motion: { seconds: .42, lift: 1.35, spin: 24, ease: 'cubic-bezier(.3,1.75,.5,1)', stagger: .07, land: 'float' },
-    sound: 'pop',
-    preview: '<rect x="18" y="8" width="28" height="48" rx="14" fill="#FFE3EE" stroke="#3D3230" stroke-width="3"/><circle cx="32" cy="44" r="9" fill="#FFB7D2" stroke="#3D3230" stroke-width="2.6"/><circle cx="32" cy="23" r="9" fill="#BFE8FF" stroke="#3D3230" stroke-width="2.6"/>',
+    preview:
+      `<rect x="2" y="2" width="60" height="60" rx="6" fill="#141A2E"/>` +
+      stack(dash.pieces[0].svg, dash.pieces[1].svg),
   },
   {
     key: 'tubes',
     title: 'Classic',
-    motion: { seconds: .22, lift: .9, spin: 0, ease: 'cubic-bezier(.3,1.2,.5,1)', stagger: .04, land: 'drop' },
+    motion: { seconds: .3, lift: 1, spin: 0, stagger: .05, land: 'drop' },
     sound: 'pop',
     preview: '<rect x="22" y="10" width="20" height="46" rx="6" fill="#fff" stroke="#3D3230" stroke-width="3"/><circle cx="32" cy="47" r="6" fill="#E5484D"/><circle cx="32" cy="34" r="6" fill="#4FA3D1"/>',
   },
@@ -80,6 +67,8 @@ export const SKINS = [
 
 const KEY = 'sortit:skin'
 
+// a saved key that no longer exists (a retired skin) falls back to the
+// default, so an old preference never strands a player on a blank board
 export function loadSkin() {
   try {
     const saved = localStorage.getItem(KEY)

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -110,7 +110,15 @@
       node.dataset.flightSeq = flightSeq
       node.classList.add('flying')
       const burst = index < 4 // a long convoy bursts only its head, not 7 puffs
-      const anim = node.animate(keyframes, flightOptions(motion, index))
+      const options = flightOptions(motion, index)
+      const anim = node.animate(keyframes, options)
+      // a broken block bursts where it BROKE, at the source, when the shudder
+      // ends (the flight's own timing), not where it respawns
+      if (burst && verb === 'breakpop') {
+        setTimeout(() => {
+          if (node.dataset.flightSeq === flightSeq) fx.land(from.rect, 'breakpop', [pieceColor(uid)])
+        }, options.delay + options.duration * 0.42)
+      }
       anim.finished.then(() => {
         if (node.dataset.flightSeq !== flightSeq) return
         node.classList.remove('flying')
@@ -141,6 +149,10 @@
   const artFor = item => item.hid ? (store.skin.hidden ?? HID_ART) : pieceFor(item).svg
   const verbFor = item => pieceFor(item)?.verb ?? store.skin.motion?.land ?? 'drop'
   const artColors = () => (store.skin.pieces ?? store.theme?.items ?? []).map(item => item.color)
+  const pieceColor = uid => {
+    for (const tube of store.tubes) for (const item of tube) if (item.uid === uid) return pieceFor(item).color
+    return '#8A6142'
+  }
 
   // the vanilla rich label: a screen-reader player solves by contents, so name
   // each piece (or "mystery"), or "empty"

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -67,14 +67,27 @@
       const node = boardEl.querySelector(`[data-uid="${uid}"]`)
       if (!node) continue
       const tube = node.closest('.tube')
-      before.set(uid, { rect: node.getBoundingClientRect(), tubeTop: tube ? tube.getBoundingClientRect().top : 0 })
+      before.set(uid, {
+        rect: node.getBoundingClientRect(),
+        tubeTop: tube ? tube.getBoundingClientRect().top : 0,
+        verb: node.dataset.verb || 'drop',
+      })
     }
   })
   $effect(() => {
-    store.moveSeq
-    if (!boardEl || !before.size) return
+    const flightSeq = String(store.moveSeq)
+    if (!boardEl) return
+    // A rapid second move or undo owns the node now. Cancel the old compositor
+    // work before starting (or declining) this sequence; its settled promise
+    // is sequence-guarded below so it cannot tear down the new flight's cue.
+    for (const node of boardEl.querySelectorAll('.item.flying')) {
+      if (node.dataset.flightSeq === flightSeq) continue
+      for (const animation of node.getAnimations()) animation.cancel()
+      node.classList.remove('flying')
+    }
+    if (!before.size) return
     if (matchMedia('(prefers-reduced-motion: reduce)').matches) { before = new Map(); return }
-    const motion = store.skin.motion ?? { seconds: .22, lift: 1, spin: 0, ease: 'ease', stagger: 0, land: 'drop' }
+    const motion = store.skin.motion ?? { seconds: .22, lift: 1, spin: 0, stagger: 0, land: 'drop' }
     let index = 0
     for (const [uid, from] of before) {
       const node = boardEl.querySelector(`[data-uid="${uid}"]`)
@@ -85,21 +98,26 @@
       // the arc peaks above BOTH mouths, so a trip between rows still clears
       const peakRel = Math.min(from.tubeTop, destTop) - to.top - motion.lift * side
       const rimRel = Math.min(-2, destTop - to.top)
-      const keyframes = flightKeyframes(motion.land, {
+      const verb = from.verb || motion.land
+      const keyframes = flightKeyframes(verb, {
         dx: from.rect.left - to.left,
         dy: from.rect.top - to.top,
         peakRel, rimRel,
         spin: motion.spin ?? 0,
       })
       for (const a of node.getAnimations()) a.cancel()
-      node.style.transformOrigin = motion.land === 'screw' ? '50% 50%' : '50% 80%'
+      node.style.transformOrigin = ['screw', 'roll', 'breakpop'].includes(verb) ? '50% 50%' : '50% 80%'
+      node.dataset.flightSeq = flightSeq
       node.classList.add('flying')
       const burst = index < 4 // a long convoy bursts only its head, not 7 puffs
       const anim = node.animate(keyframes, flightOptions(motion, index))
       anim.finished.then(() => {
+        if (node.dataset.flightSeq !== flightSeq) return
         node.classList.remove('flying')
-        if (burst) fx.land(node.getBoundingClientRect(), motion.land, store.theme?.items.map(i => i.color) ?? [])
-      }).catch(() => node.classList.remove('flying'))
+        if (burst) fx.land(node.getBoundingClientRect(), verb, artColors())
+      }).catch(() => {
+        if (node.dataset.flightSeq === flightSeq) node.classList.remove('flying')
+      })
       index += 1
     }
     before = new Map()
@@ -119,12 +137,15 @@
   })
 
   const HID_ART = '<circle cx="32" cy="32" r="22" fill="#C9BCB2" stroke="#3D3230" stroke-width="3"/><path d="M26 28 Q26 21 32 21 Q38 21 38 27 Q38 32 32 33 L32 36" stroke="#3D3230" stroke-width="3.6" fill="none" stroke-linecap="round"/><circle cx="32" cy="43" r="2.4" fill="#3D3230"/>'
-  const artFor = item => item.hid ? HID_ART : store.theme.items[item.c].svg
+  const pieceFor = item => store.skin.pieces?.[item.c] ?? store.theme.items[item.c]
+  const artFor = item => item.hid ? (store.skin.hidden ?? HID_ART) : pieceFor(item).svg
+  const verbFor = item => pieceFor(item)?.verb ?? store.skin.motion?.land ?? 'drop'
+  const artColors = () => (store.skin.pieces ?? store.theme?.items ?? []).map(item => item.color)
 
   // the vanilla rich label: a screen-reader player solves by contents, so name
   // each piece (or "mystery"), or "empty"
   const tubeLabel = (index) => {
-    const named = store.tubes[index].map(i => i.hid ? 'mystery' : store.theme.items[i.c].key)
+    const named = store.tubes[index].map(i => i.hid ? 'mystery' : pieceFor(i).key)
     return `tube ${index + 1}: ${named.join(', ') || 'empty'}`
   }
 
@@ -157,7 +178,13 @@
           aria-label={tubeLabel(index)}
         >
           {#each store.tubes[index] as item (item.uid)}
-            <span class="item" class:hid={item.hid} class:lift={isLifted(index, item)} data-uid={item.uid}>
+            <span
+              class="item"
+              class:hid={item.hid}
+              class:lift={isLifted(index, item)}
+              data-uid={item.uid}
+              data-verb={verbFor(item)}
+            >
               <svg viewBox="0 0 64 64" aria-hidden="true">{@html artFor(item)}</svg>
             </span>
           {/each}

--- a/src/lib/ui/flight.js
+++ b/src/lib/ui/flight.js
@@ -64,6 +64,58 @@ export function flightKeyframes(verb, { dx, dy, peakRel, rimRel, spin }) {
         { transform: 'translate(0px, -2px) rotate(0deg)', easing: 'ease-in-out', offset: 0.92 },
         { transform: 'translate(0px, 0px) rotate(0deg) scale(1,1)', offset: 1 },
       ]
+    case 'breakpop':
+      // Mine conversion: the source block shudders apart, disappears, then
+      // respawns in the destination. The invisible one-frame position swap is
+      // deliberate: this is a destroy/create verb, not a flying block.
+      return [
+        { transform: `${start} rotate(0deg) scale(1)`, opacity: 1, offset: 0 },
+        { transform: `translate(${dx - 3}px, ${dy + 1}px) rotate(-4deg) scale(1.04)`, opacity: 1, offset: 0.2 },
+        { transform: `translate(${dx + 3}px, ${dy - 1}px) rotate(4deg) scale(.88)`, opacity: 0.85, offset: 0.34 },
+        { transform: `${start} rotate(0deg) scale(.08)`, opacity: 0, offset: 0.45 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(.08)', opacity: 0, offset: 0.46 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(1.14)', opacity: 1, easing: 'ease-out', offset: 0.76 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(1)', opacity: 1, offset: 1 },
+      ]
+    case 'flip':
+      return [
+        { transform: `${start} rotate(0deg)`, easing: LAUNCH, offset: 0 },
+        { transform: `${peak(0.42)} rotate(${spin * 0.55}deg)`, easing: CRUISE, offset: 0.46 },
+        { transform: `translate(0px, -4px) rotate(${spin}deg) scale(1.08,.92)`, easing: 'ease-out', offset: 0.82 },
+        { transform: `translate(0px, 0px) rotate(${settled(spin)}deg) scale(1,1)`, offset: 1 },
+      ]
+    case 'roll': {
+      const turns = spin % 360 === 0 ? spin * 2 : 720
+      return [
+        { transform: `${start} rotate(0deg)`, easing: 'ease-in', offset: 0 },
+        { transform: `${peak(0.28)} rotate(${turns * 0.45}deg)`, easing: 'linear', offset: 0.44 },
+        { transform: `translate(0px, 0px) rotate(${turns}deg) scale(1.08,.92)`, easing: 'ease-out', offset: 0.88 },
+        { transform: `translate(0px, 0px) rotate(${turns}deg) scale(1,1)`, offset: 1 },
+      ]
+    }
+    case 'fly':
+      return [
+        { transform: `${start} rotate(0deg) scale(.96)`, easing: 'ease-in', offset: 0 },
+        { transform: `${peak(0.35)} rotate(-16deg) scale(1.04)`, easing: CRUISE, offset: 0.38 },
+        { transform: `translate(${dx * 0.22}px, ${peakRel * 0.58}px) rotate(10deg) scale(1.03)`, easing: 'ease-out', offset: 0.68 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(1,1)', offset: 1 },
+      ]
+    case 'hover':
+      return [
+        { transform: `${start} rotate(0deg)`, easing: 'ease-in-out', offset: 0 },
+        { transform: `${peak(0.32)} rotate(-5deg) translateY(-3px)`, easing: 'ease-in-out', offset: 0.34 },
+        { transform: `translate(${dx * 0.28}px, ${peakRel * 0.72}px) rotate(5deg) translateY(3px)`, easing: 'ease-in-out', offset: 0.64 },
+        { transform: 'translate(0px, -4px) rotate(0deg)', easing: 'ease-out', offset: 0.88 },
+        { transform: 'translate(0px, 0px) rotate(0deg)', offset: 1 },
+      ]
+    case 'zig':
+      return [
+        { transform: `${start} rotate(0deg)`, easing: 'linear', offset: 0 },
+        { transform: `translate(${dx * 0.72}px, ${peakRel}px) rotate(-18deg)`, easing: 'linear', offset: 0.28 },
+        { transform: `translate(${dx * 0.46}px, ${dy * 0.25}px) rotate(18deg)`, easing: 'linear', offset: 0.5 },
+        { transform: `translate(${dx * 0.2}px, ${peakRel * 0.55}px) rotate(-18deg)`, easing: 'linear', offset: 0.72 },
+        { transform: 'translate(0px, 0px) rotate(0deg)', offset: 1 },
+      ]
     default:
       // 'drop': the plain arc with a soft touch
       return [
@@ -82,14 +134,30 @@ export function flightOptions(motion, index) {
   return {
     duration: Math.max(1, motion.seconds * 1000),
     delay: index * (motion.stagger ?? 0) * 1000,
-    easing: motion.ease ?? 'linear',
+    // Segment keyframes own their easing. A second effect-level easing bends
+    // the offsets themselves, so audio scheduled at a touchdown offset lands
+    // visibly early or late.
+    easing: 'linear',
     fill: 'backwards',
   }
 }
 
 // when each landing happens on the audio clock, so sounds.js can schedule the
 // material's note per item without a js timer racing the compositor.
-export function landingTimes(motion, count) {
-  const beat = { screw: 0.52, bounce: 0.78, slide: 0.92, zip: 1, float: 0.82, drop: 0.86 }[motion.land] ?? 0.86
+export function landingTimes(motion, count, verb = motion.land) {
+  const beat = {
+    screw: 0.52,
+    breakpop: 0.76,
+    flip: 0.82,
+    roll: 0.88,
+    fly: 1,
+    hover: 0.88,
+    zig: 1,
+    bounce: 0.78,
+    slide: 0.92,
+    zip: 1,
+    float: 0.82,
+    drop: 0.86,
+  }[verb] ?? 0.86
   return Array.from({ length: count }, (_, i) => motion.seconds * beat + i * (motion.stagger ?? 0))
 }

--- a/src/lib/ui/fx.js
+++ b/src/lib/ui/fx.js
@@ -29,6 +29,12 @@ function fit() {
 // the burst recipes, keyed by the skin's landing verb
 const RECIPES = {
   screw: { n: 7, colors: ['#FFE9A8', '#FFD54A', '#FFFFFF'], shape: 'spark', speed: 130, up: .4, grav: 260, life: .28 },
+  breakpop: { n: 14, colors: ['#B9A38C', '#75604A', '#D8C7A9'], shape: 'chunk', speed: 125, up: .85, grav: 460, life: .38 },
+  flip: { n: 9, colors: ['#3EF0D0', '#FF4FD8', '#FFFFFF'], shape: 'spark', speed: 165, up: .35, grav: 80, life: .24 },
+  roll: { n: 7, colors: ['#FFE63F', '#FF8A00', '#FFFFFF'], shape: 'spark', speed: 120, up: .3, grav: 150, life: .24 },
+  fly: { n: 8, colors: ['#3F7BFF', '#3EF0D0', '#FFFFFF'], shape: 'spark', speed: 180, up: .55, grav: 40, life: .3 },
+  hover: { n: 8, colors: ['#3FFFB0', '#FF7FD2', '#FFFFFF'], shape: 'dot', speed: 75, up: 1, grav: -45, life: .42 },
+  zig: { n: 10, colors: ['#FFC53F', '#3EF0D0', '#FFFFFF'], shape: 'spark', speed: 190, up: .25, grav: 30, life: .22 },
   bounce: { n: 10, colors: ['#B9A38C', '#8A7A70', '#D8CFC6'], shape: 'chunk', speed: 110, up: .8, grav: 420, life: .34 },
   drop: { n: 8, colors: ['#FFFFFF', '#DCEFFA', '#BFE3F5'], shape: 'dot', speed: 90, up: .9, grav: 150, life: .3 },
   slide: { n: 6, colors: ['#D8C4A6', '#B79A76', '#FFF3DD'], shape: 'chunk', speed: 90, up: .7, grav: 380, life: .26 },
@@ -71,9 +77,9 @@ function loop(now) {
 }
 
 export const fx = {
-  // rect: the landed item's viewport box. verb picks the recipe; the theme's
-  // item colors tint half the particles so bursts belong to the board.
-  land(rect, verb, themeColors = []) {
+  // rect: the landed item's viewport box. verb picks the recipe; the active
+  // conversion's colors tint half the particles so bursts belong to its art.
+  land(rect, verb, artColors = []) {
     if (typeof document === 'undefined') return
     ensure()
     fit()
@@ -84,7 +90,7 @@ export const fx = {
     for (let i = 0; i < r.n; i++) {
       const angle = Math.PI * (1 + (i / (r.n - 1))) // fan across the upper half
       const speed = r.speed * (0.5 + Math.random() * 0.7)
-      const palette = (i % 2 === 0 && themeColors.length) ? themeColors : r.colors
+      const palette = (i % 2 === 0 && artColors.length) ? artColors : r.colors
       parts.push({
         x: cx + (Math.random() - 0.5) * rect.width * 0.5,
         y: cy,

--- a/src/lib/ui/sounds.js
+++ b/src/lib/ui/sounds.js
@@ -94,6 +94,10 @@ const MATERIALS = {
     noise({ at, len: 0.05, vol: 0.07, freq: 900, q: 0.8 })
   },
   stone(at) {
+    // the break: two crunches while the source block shudders, then the pop
+    // where it respawns. spacing matches the breakpop keyframes by ear.
+    noise({ at: Math.max(0, at - 0.2), len: 0.06, vol: 0.09, freq: 900, q: 0.7 })
+    noise({ at: Math.max(0, at - 0.1), len: 0.07, vol: 0.11, freq: 600, q: 0.7 })
     tone({ freq: 150, glide: 90, type: 'sine', at, len: 0.12, vol: 0.16 })
     noise({ at, len: 0.09, vol: 0.1, freq: 420, q: 0.6 })
   },

--- a/src/lib/ui/store.svelte.js
+++ b/src/lib/ui/store.svelte.js
@@ -120,6 +120,8 @@ export function createStore() {
     return { from, to, count: Math.min(visibleRun(from), space) }
   }
 
+  const moveVerb = color => skin.pieces?.[color]?.verb ?? skin.motion?.land ?? 'drop'
+
   function anyPlayerMove() {
     for (let from = 0; from < tubes.length; from++) {
       if (!tubes[from].length || isComplete(colorsOf(tubes[from]), capacity)) continue
@@ -171,6 +173,7 @@ export function createStore() {
       else sound.no()
       return
     }
+    const movingColor = tubes[move.from][tubes[move.from].length - 1].c
     history.push({ tubes: tubes.map(t => t.map(i => ({ ...i }))), moves })
     lastMovedUids = tubes[move.from].slice(-move.count).map(i => i.uid)
     const next = tubes.map(t => t.slice())
@@ -183,7 +186,7 @@ export function createStore() {
     // each landed item sounds at its own touchdown; with motion off there is
     // no flight to wait for, so the whole phrase lands now
     const still = typeof matchMedia !== 'undefined' && matchMedia('(prefers-reduced-motion: reduce)').matches
-    sound.move(skin.sound ?? 'pop', still ? [0] : landingTimes(skin.motion, move.count))
+    sound.move(skin.sound ?? 'pop', still ? [0] : landingTimes(skin.motion, move.count, moveVerb(movingColor)))
     const doneNow = isComplete(colorsOf(tubes[move.to]), capacity)
     if (doneNow && !isWin(numeric(), capacity)) sound.tube()
     if (isWin(numeric(), capacity)) { finishWin(); return }
@@ -199,6 +202,8 @@ export function createStore() {
     board = b
     board.par = null
     theme = themeForBoard(b)
+    lastMovedUids = []
+    moveSeq += 1
     capacity = b.params.capacity
     uidNext = 0
     tubes = b.tubes.map(t => t.map((c, slot) => ({ uid: uidNext++, c, hid: b.params.hidden && slot < t.length - 1 })))
@@ -265,6 +270,8 @@ export function createStore() {
     undo() {
       const last = history.pop()
       if (!last) return
+      lastMovedUids = []
+      moveSeq += 1
       for (const t of last.tubes) for (const it of t) if (seen.has(it.uid)) it.hid = false
       tubes = last.tubes
       selected = null
@@ -282,7 +289,12 @@ export function createStore() {
       setTimeout(() => { hintTubes = [] }, 2000)
       return m
     },
-    setSkin(next) { skin = next; saveSkin(next) },
+    setSkin(next) {
+      lastMovedUids = []
+      moveSeq += 1
+      skin = next
+      saveSkin(next)
+    },
     setShellTheme(next) { shellTheme = next; saveTheme(next.key); applyTheme(next) },
     openDialog(d) { dialog = d },
     closeDialog() { dialog = null },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -256,7 +256,7 @@
           </button>
         {/each}
       </div>
-      <p class="small">Same puzzles, different costume. Changing it never touches your game.</p>
+      <p class="small">Same puzzles, totally different worlds. Your progress stays right where it is.</p>
       <button class="big" onclick={close}>DONE</button>
     {/snippet}
   </Modal>

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -1,74 +1,130 @@
-// proves the flight geometry in node, the same way levels and stars are
-// proven: every skin's landing verb must produce a path that starts at the
-// old spot, actually rises over the arc peak, ends seated at the origin
-// reading upright, and keeps its offsets ascending (the web animations api
-// throws on a descending offset list at runtime, where no test would see it).
+// Proves the total-conversion contract and every movement geometry in Node.
+// The browser owns pixels; this gate owns the data that makes those pixels
+// possible: twelve unique pieces, a mystery piece, valid per-piece verbs,
+// stable Classic fallback, and flights that start and finish where they say.
 import { SKINS } from '../src/lib/engine/skins.js'
 import { flightKeyframes, flightOptions, landingTimes } from '../src/lib/ui/flight.js'
+import { readFileSync } from 'node:fs'
 
 let failures = 0
 const fail = msg => { failures += 1; console.error('FAIL ' + msg) }
 
 const GEO = { dx: -120, dy: 80, peakRel: -140, rimRel: -60 }
-const VERBS = ['drop', 'screw', 'slide', 'bounce', 'zip', 'float']
-const MATERIALS = ['glass', 'metal', 'wood', 'stone', 'neon', 'pop']
+const VERBS = new Set(['drop', 'screw', 'breakpop', 'flip', 'roll', 'fly', 'hover', 'zig'])
+const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop'])
+const CONVERSIONS = ['bolts', 'mine', 'dash', 'tubes']
+const CSS = readFileSync(new URL('../src/app.css', import.meta.url), 'utf8')
 
-const translateOf = t => {
-  const m = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(t)
-  return m ? { x: Number(m[1]), y: Number(m[2]) } : null
+const translateOf = transform => {
+  const match = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(transform)
+  return match ? { x: Number(match[1]), y: Number(match[2]) } : null
 }
-const rotationOf = t => {
-  const m = /rotate\((-?[\d.]+)deg\)/.exec(t)
-  return m ? Number(m[1]) : 0
+
+const rotationOf = transform => {
+  const match = /rotate\((-?[\d.]+)deg\)/.exec(transform)
+  return match ? Number(match[1]) : 0
+}
+
+function verifyFlight(verb, motion, id) {
+  const keyframes = flightKeyframes(verb, { ...GEO, spin: motion.spin })
+  if (keyframes.length < 3) fail(`${id}: fewer than 3 keyframes`)
+
+  const first = translateOf(keyframes[0].transform)
+  if (!first || first.x !== GEO.dx || first.y !== GEO.dy) {
+    fail(`${id}: flight does not start at the old spot (${keyframes[0].transform})`)
+  }
+  if (rotationOf(keyframes[0].transform) !== 0) fail(`${id}: starts pre-rotated`)
+
+  const last = translateOf(keyframes.at(-1).transform)
+  if (!last || last.x !== 0 || last.y !== 0) {
+    fail(`${id}: flight does not end seated at the origin (${keyframes.at(-1).transform})`)
+  }
+  if (rotationOf(keyframes.at(-1).transform) % 360 !== 0) {
+    fail(`${id}: lands tilted (${keyframes.at(-1).transform})`)
+  }
+
+  if (verb === 'breakpop') {
+    const hiddenAtDestination = keyframes.some(frame => {
+      const point = translateOf(frame.transform)
+      return frame.opacity === 0 && point?.x === 0 && point?.y === 0
+    })
+    if (!hiddenAtDestination) fail(`${id}: destroy/create swap is visible`)
+  } else {
+    const ys = keyframes.map(frame => translateOf(frame.transform)).filter(Boolean).map(point => point.y)
+    if (Math.min(...ys) > GEO.peakRel + 1) {
+      fail(`${id}: path never reaches the arc peak (min y ${Math.min(...ys)})`)
+    }
+  }
+
+  if (keyframes[0].offset !== 0) fail(`${id}: first offset is not 0`)
+  if (keyframes.at(-1).offset !== 1) fail(`${id}: last offset is not 1`)
+  let previous = -1
+  for (const frame of keyframes) {
+    if (frame.offset == null) fail(`${id}: keyframe missing offset`)
+    else if (frame.offset <= previous) fail(`${id}: offsets descend at ${frame.offset}`)
+    else previous = frame.offset
+  }
+
+  const times = landingTimes(motion, 4, verb)
+  if (times.length !== 4) fail(`${id}: landingTimes count wrong`)
+  for (let i = 1; i < times.length; i++) {
+    if (times[i] <= times[i - 1]) fail(`${id}: landing times not ascending`)
+  }
+  if (times[0] <= 0 || times[0] > motion.seconds) {
+    fail(`${id}: first landing outside the animation`)
+  }
+}
+
+if (SKINS.map(skin => skin.key).join(',') !== CONVERSIONS.join(',')) {
+  fail(`v1 conversion set/order drifted: ${SKINS.map(skin => skin.key).join(',')}`)
 }
 
 for (const skin of SKINS) {
   const id = `skin ${skin.key}`
   const motion = skin.motion ?? {}
-  for (const field of ['seconds', 'lift', 'spin', 'ease', 'stagger', 'land']) {
+  for (const field of ['seconds', 'lift', 'spin', 'stagger', 'land']) {
     if (motion[field] == null) fail(`${id}: motion.${field} missing`)
   }
-  if (!VERBS.includes(motion.land)) fail(`${id}: unknown landing verb ${motion.land}`)
-  if (!MATERIALS.includes(skin.sound)) fail(`${id}: unknown sound material ${skin.sound}`)
-
-  const kf = flightKeyframes(motion.land, { ...GEO, spin: motion.spin })
-  if (kf.length < 3) fail(`${id}: fewer than 3 keyframes`)
-
-  const first = translateOf(kf[0].transform)
-  if (!first || first.x !== GEO.dx || first.y !== GEO.dy) fail(`${id}: flight does not start at the old spot (${kf[0].transform})`)
-  if (rotationOf(kf[0].transform) !== 0) fail(`${id}: flight starts pre-rotated`)
-
-  const last = translateOf(kf[kf.length - 1].transform)
-  if (!last || last.x !== 0 || last.y !== 0) fail(`${id}: flight does not end seated at the origin (${kf[kf.length - 1].transform})`)
-  if (rotationOf(kf[kf.length - 1].transform) % 360 !== 0) fail(`${id}: lands tilted (${kf[kf.length - 1].transform})`)
-
-  const ys = kf.map(k => translateOf(k.transform)).filter(Boolean).map(p => p.y)
-  if (Math.min(...ys) > GEO.peakRel + 1) fail(`${id}: arc never reaches the peak (min y ${Math.min(...ys)}, peak ${GEO.peakRel})`)
-
-  if (kf[0].offset !== 0) fail(`${id}: first offset is ${kf[0].offset}, not 0`)
-  if (kf[kf.length - 1].offset !== 1) fail(`${id}: last offset is ${kf[kf.length - 1].offset}, not 1`)
-  let prev = -1
-  for (const k of kf) {
-    if (k.offset == null) fail(`${id}: a keyframe is missing its offset`)
-    else if (k.offset <= prev) fail(`${id}: offsets not ascending (${k.offset} after ${prev})`)
-    else prev = k.offset
+  if (!VERBS.has(motion.land)) fail(`${id}: unknown default verb ${motion.land}`)
+  if (!MATERIALS.has(skin.sound)) fail(`${id}: unknown sound material ${skin.sound}`)
+  if (!skin.preview?.includes('<')) fail(`${id}: preview is empty`)
+  if (skin.key !== 'tubes' && !CSS.includes(`[data-skin="${skin.key}"]`)) {
+    fail(`${id}: no board furniture css`)
   }
 
-  const opts = flightOptions(motion, 2)
-  if (opts.duration !== motion.seconds * 1000) fail(`${id}: duration ${opts.duration} != ${motion.seconds * 1000}`)
-  if (opts.delay !== 2 * motion.stagger * 1000) fail(`${id}: convoy delay ${opts.delay} wrong for index 2`)
-  if (opts.fill !== 'backwards') fail(`${id}: fill must hold items at launch through their stagger delay`)
+  const verbs = new Set([motion.land])
+  if (skin.key === 'tubes') {
+    if (skin.pieces != null || skin.hidden != null) fail('Classic must keep using world art')
+  } else {
+    if (skin.pieces?.length !== 12) fail(`${id}: expected 12 pieces, got ${skin.pieces?.length ?? 0}`)
+    if (!skin.hidden?.includes('<')) fail(`${id}: mystery piece is empty`)
+    const keys = new Set()
+    const svgs = new Set()
+    for (const [index, piece] of (skin.pieces ?? []).entries()) {
+      if (!piece.key || keys.has(piece.key)) fail(`${id}: piece ${index} has a missing/duplicate key`)
+      keys.add(piece.key)
+      if (!/^#[0-9a-f]{6}$/i.test(piece.color ?? '')) fail(`${id}: piece ${index} has invalid color`)
+      if (!/<(?:path|rect|circle|ellipse|polygon|g)\b/.test(piece.svg ?? '')) fail(`${id}: piece ${index} has no vector art`)
+      if (/<script\b|\son\w+=/i.test(piece.svg ?? '')) fail(`${id}: piece ${index} has active markup`)
+      if (svgs.has(piece.svg)) fail(`${id}: piece ${index} duplicates another piece's art`)
+      svgs.add(piece.svg)
+      const verb = piece.verb ?? motion.land
+      if (!VERBS.has(verb)) fail(`${id}: piece ${index} has unknown verb ${verb}`)
+      verbs.add(verb)
+    }
+  }
 
-  const times = landingTimes(motion, 4)
-  if (times.length !== 4) fail(`${id}: landingTimes count wrong`)
-  for (let i = 1; i < times.length; i++) if (times[i] <= times[i - 1]) fail(`${id}: landing times not ascending`)
-  if (times[0] <= 0 || times[0] > motion.seconds) fail(`${id}: first landing outside the flight (${times[0]}s of ${motion.seconds}s)`)
+  for (const verb of verbs) verifyFlight(verb, motion, `${id}/${verb}`)
+
+  const options = flightOptions(motion, 2)
+  if (options.duration !== motion.seconds * 1000) fail(`${id}: duration is wrong`)
+  if (options.delay !== 2 * motion.stagger * 1000) fail(`${id}: convoy delay is wrong`)
+  if (options.fill !== 'backwards') fail(`${id}: stagger does not hold the launch pose`)
+  if (options.easing !== 'linear') fail(`${id}: effect easing would desync audio from keyframe offsets`)
 }
 
-// the classic skin must still exist (a saved 'tubes' preference keeps working)
-// and glass must be the default for a fresh player (SKINS[0] is the fallback)
-if (SKINS[0]?.key !== 'glass') fail('glass is not the default skin')
-if (!SKINS.some(s => s.key === 'tubes')) fail('the classic tubes skin is gone')
-
-if (failures) { console.error(`${failures} flight problem(s)`); process.exit(1) }
-console.log(`flight ok: ${SKINS.length} skins, ${VERBS.length} verbs proven`)
+if (failures) {
+  console.error(`${failures} conversion/flight problem(s)`)
+  process.exit(1)
+}
+console.log(`flight ok: ${SKINS.length} conversions, ${VERBS.size} verbs, 36 custom pieces proven`)


### PR DESCRIPTION
## What changed

- make Nuts & Bolts, Block Mine, and Neon Dash own their twelve pieces, mystery art, board furniture, and movement verbs
- keep Classic on the existing world art and leave the puzzle engine/scoring untouched
- wire skin-owned art into rendering, screen-reader labels, landing colors, sound timing, undo, and rapid move cleanup
- add break/pop, flip, roll, fly, hover, and zig movement geometry
- keep whole-effect timing linear so keyframe touchdown and synthesized sound stay aligned
- expand the verifier across four conversions, eight verbs, 36 custom pieces, CSS coverage, and unsafe SVG rejection

## Verified

- npm run verify
- npm run lint:copy
- npm run svelte-check (0 errors, 0 warnings)
- npm run build
- git diff --check
- verifier mutation probes: missing conversion/CSS and unknown piece verb both fail
- real browser: custom nut, mine, and dash art/labels render; mine break/pop enters an active flight

Refs #29.