### PR TITLE
kawaii pop: twelve round friends with a squish-hop and cute sounds (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -332,6 +332,26 @@ h1 {
 [data-skin="dash"] .tube.done { box-shadow: 0 0 0 3px #3EF0D0, 0 0 18px 5px rgb(62 240 208 / .6); }
 
 
+/* kawaii pop: a pastel nursery. soft rounded cups, a candy-striped floor,
+   and the friends' own bodies do the rest. an aesthetic tribute. */
+#board[data-skin="kawaii"] {
+  background:
+    radial-gradient(circle at 15% 12%, rgb(255 255 255 / .8), transparent 18%),
+    radial-gradient(circle at 85% 20%, rgb(255 255 255 / .7), transparent 14%),
+    repeating-linear-gradient(90deg, rgb(255 255 255 / .35) 0 14px, transparent 14px 28px) 0 100% / 100% 12% no-repeat,
+    linear-gradient(180deg, #FFE3EE 0 88%, #FFC9DD 88%) !important;
+}
+[data-skin="kawaii"] .tube {
+  border: .22rem solid #E8A9C4;
+  border-radius: 1.3rem;
+  background: linear-gradient(180deg, rgb(255 246 250 / .95), rgb(255 226 238 / .8));
+  box-shadow: inset 0 4px 8px -4px rgb(255 255 255 / .95), 0 5px 8px -4px rgb(232 169 196 / .7);
+}
+[data-skin="kawaii"] .item { position: relative; padding: 0; filter: drop-shadow(0 3px 2px rgb(232 169 196 / .5)); }
+[data-skin="kawaii"] .item svg { scale: .94; }
+[data-skin="kawaii"] .tube.sel { box-shadow: 0 .35rem 0 #E8A9C4; }
+[data-skin="kawaii"] .tube.done { box-shadow: 0 0 0 3px #FF8FB1, 0 0 16px 4px rgb(255 143 177 / .55); }
+
 /* the selected lift and done cues stay identical across skins on purpose:
    the READING of the board never changes, only its world */
 

--- a/src/lib/engine/skinart/kawaii.js
+++ b/src/lib/engine/skinart/kawaii.js
@@ -1,0 +1,138 @@
+// kawaii pieces: twelve tiny round friends, every one a different creature so
+// silhouettes sort as well as colours do. soft pastel bodies, a bold warm
+// outline, dot eyes with a glint, a blush, and the smallest possible mouth.
+// they hop between tubes with a squish (see flight.js 'squish'). viewBox
+// 0 0 64 64.
+//
+// exports { pieces: [12 x { key, color, svg }], hidden: svg }
+
+const INK = '#3D3230'
+const SW = 2.6
+
+// the face: two glinting dot eyes, a blush on each cheek, and a mouth
+function face(cx, cy, spread = 8, mouth = 'w') {
+  const mouths = {
+    w: `<path d="M${cx - 3} ${cy + 5} q1.5 2.5 3 0 q1.5 2.5 3 0" stroke="${INK}" stroke-width="1.8" fill="none" stroke-linecap="round"/>`,
+    smile: `<path d="M${cx - 3.5} ${cy + 4.5} q3.5 4 7 0" stroke="${INK}" stroke-width="1.8" fill="none" stroke-linecap="round"/>`,
+    o: `<circle cx="${cx}" cy="${cy + 5.5}" r="1.8" fill="${INK}"/>`,
+    cat: `<path d="M${cx - 3.5} ${cy + 4} q1.75 3 3.5 0 q1.75 3 3.5 0" stroke="${INK}" stroke-width="1.8" fill="none" stroke-linecap="round"/>`,
+  }
+  return (
+    `<circle cx="${cx - spread}" cy="${cy}" r="2.6" fill="${INK}"/><circle cx="${cx + spread}" cy="${cy}" r="2.6" fill="${INK}"/>` +
+    `<circle cx="${cx - spread + 1}" cy="${cy - 1}" r=".9" fill="#fff"/><circle cx="${cx + spread + 1}" cy="${cy - 1}" r=".9" fill="#fff"/>` +
+    `<circle cx="${cx - spread - 4}" cy="${cy + 4}" r="2.6" fill="#FF8FB1" opacity=".55"/><circle cx="${cx + spread + 4}" cy="${cy + 4}" r="2.6" fill="#FF8FB1" opacity=".55"/>` +
+    mouths[mouth]
+  )
+}
+
+const body = (d, fill) => `<path d="${d}" fill="${fill}" stroke="${INK}" stroke-width="${SW}" stroke-linejoin="round"/>`
+const blob = (cx, cy, rx, ry, fill) => `<ellipse cx="${cx}" cy="${cy}" rx="${rx}" ry="${ry}" fill="${fill}" stroke="${INK}" stroke-width="${SW}"/>`
+
+const pieces = [
+  {
+    key: 'bun', color: '#FFB7D2',
+    svg:
+      blob(24, 20, 5.5, 13, '#FFB7D2') + `<ellipse cx="24" cy="21" rx="2.5" ry="8" fill="#FF8FB1" opacity=".7"/>` +
+      blob(40, 20, 5.5, 13, '#FFB7D2') + `<ellipse cx="40" cy="21" rx="2.5" ry="8" fill="#FF8FB1" opacity=".7"/>` +
+      blob(32, 40, 21, 18, '#FFB7D2') + face(32, 39, 8, 'w'),
+  },
+  {
+    key: 'kitty', color: '#C9CED8',
+    svg:
+      body('M14 34 L12 12 L28 22 L36 22 L52 12 L50 34 Z', '#C9CED8') +
+      `<path d="M16 20 L19 27 L24 24 Z M48 20 L45 27 L40 24 Z" fill="#FFB7D2"/>` +
+      blob(32, 40, 20, 17, '#C9CED8') + face(32, 39, 8, 'cat') +
+      `<path d="M4 38 L14 40 M4 46 L14 44 M60 38 L50 40 M60 46 L50 44" stroke="${INK}" stroke-width="1.6" stroke-linecap="round"/>`,
+  },
+  {
+    key: 'froggy', color: '#8FE08A',
+    svg:
+      `<circle cx="20" cy="22" r="8" fill="#8FE08A" stroke="${INK}" stroke-width="${SW}"/><circle cx="44" cy="22" r="8" fill="#8FE08A" stroke="${INK}" stroke-width="${SW}"/>` +
+      blob(32, 40, 24, 17, '#8FE08A') +
+      `<circle cx="20" cy="22" r="3" fill="${INK}"/><circle cx="44" cy="22" r="3" fill="${INK}"/><circle cx="21" cy="21" r="1" fill="#fff"/><circle cx="45" cy="21" r="1" fill="#fff"/>` +
+      `<circle cx="16" cy="42" r="3" fill="#FF8FB1" opacity=".55"/><circle cx="48" cy="42" r="3" fill="#FF8FB1" opacity=".55"/>` +
+      `<path d="M22 42 q10 8 20 0" stroke="${INK}" stroke-width="1.8" fill="none" stroke-linecap="round"/>`,
+  },
+  {
+    key: 'bear', color: '#C9925E',
+    svg:
+      `<circle cx="16" cy="18" r="8" fill="#C9925E" stroke="${INK}" stroke-width="${SW}"/><circle cx="48" cy="18" r="8" fill="#C9925E" stroke="${INK}" stroke-width="${SW}"/>` +
+      `<circle cx="16" cy="18" r="3.5" fill="#F2D2B0"/><circle cx="48" cy="18" r="3.5" fill="#F2D2B0"/>` +
+      blob(32, 38, 22, 19, '#C9925E') +
+      `<ellipse cx="32" cy="45" rx="9" ry="6.5" fill="#F2D2B0"/><ellipse cx="32" cy="42.5" rx="3.2" ry="2.4" fill="${INK}"/>` +
+      face(32, 34, 9, 'smile'),
+  },
+  {
+    key: 'chick', color: '#FFE66D',
+    svg:
+      body('M32 12 C46 12 54 26 54 40 C54 52 44 58 32 58 C20 58 10 52 10 40 C10 26 18 12 32 12 Z', '#FFE66D') +
+      `<path d="M30 8 q2 -5 4 0 q-2 3 -4 0" fill="#FFB020"/>` +
+      `<ellipse cx="14" cy="42" rx="5" ry="8" fill="#FFD84A" stroke="${INK}" stroke-width="2"/>` +
+      face(34, 32, 7, 'o') + `<path d="M31 37.5 L37 37.5 L34 41 Z" fill="#FFB020" stroke="${INK}" stroke-width="1.4" stroke-linejoin="round"/>`,
+  },
+  {
+    key: 'piggy', color: '#FFA48B',
+    svg:
+      `<path d="M14 26 L10 12 L24 20 Z M50 26 L54 12 L40 20 Z" fill="#FFA48B" stroke="${INK}" stroke-width="${SW}" stroke-linejoin="round"/>` +
+      blob(32, 38, 22, 19, '#FFA48B') +
+      `<ellipse cx="32" cy="44" rx="8" ry="5.5" fill="#FF8A6E" stroke="${INK}" stroke-width="2"/><circle cx="29" cy="44" r="1.4" fill="${INK}"/><circle cx="35" cy="44" r="1.4" fill="${INK}"/>` +
+      face(32, 33, 9, 'w'),
+  },
+  {
+    key: 'whale', color: '#7FB8FF',
+    svg:
+      body('M8 40 C8 24 20 16 34 16 C48 16 56 26 56 38 C56 48 48 54 34 54 C20 54 8 50 8 40 Z', '#7FB8FF') +
+      body('M50 30 L62 20 L60 34 L62 44 L48 40 Z', '#7FB8FF') +
+      `<path d="M30 16 q-2 -8 4 -10 M30 16 q4 -8 8 -6" stroke="#7FB8FF" stroke-width="2.4" fill="none" stroke-linecap="round"/>` +
+      `<ellipse cx="26" cy="46" rx="14" ry="6" fill="#DDEFFF"/>` +
+      face(28, 34, 8, 'smile'),
+  },
+  {
+    key: 'star', color: '#C58CFF',
+    svg:
+      body('M32 6 L39 24 L58 25 L43 37 L48 56 L32 45 L16 56 L21 37 L6 25 L25 24 Z', '#C58CFF') +
+      face(32, 32, 7, 'smile'),
+  },
+  {
+    key: 'cloud', color: '#DDEFFF',
+    svg:
+      `<circle cx="20" cy="36" r="12" fill="#DDEFFF" stroke="${INK}" stroke-width="${SW}"/><circle cx="34" cy="28" r="14" fill="#DDEFFF" stroke="${INK}" stroke-width="${SW}"/><circle cx="46" cy="38" r="11" fill="#DDEFFF" stroke="${INK}" stroke-width="${SW}"/>` +
+      `<rect x="14" y="36" width="38" height="14" rx="7" fill="#DDEFFF"/><path d="M10 44 q22 10 44 0" stroke="${INK}" stroke-width="${SW}" fill="none" stroke-linecap="round"/>` +
+      `<circle cx="20" cy="36" r="12" fill="#DDEFFF"/><circle cx="34" cy="28" r="14" fill="#DDEFFF"/><circle cx="46" cy="38" r="11" fill="#DDEFFF"/>` +
+      face(33, 34, 8, 'w'),
+  },
+  {
+    key: 'onigiri', color: '#FFFFFF',
+    svg:
+      body('M32 8 C40 8 54 34 56 44 C57 50 52 54 46 54 L18 54 C12 54 7 50 8 44 C10 34 24 8 32 8 Z', '#FFFFFF') +
+      `<path d="M20 54 L20 42 C20 40 22 38 24 38 L40 38 C42 38 44 40 44 42 L44 54 Z" fill="#2F3B2A" stroke="${INK}" stroke-width="2"/>` +
+      face(32, 28, 7, 'w'),
+  },
+  {
+    key: 'mochi', color: '#B8F0D8',
+    svg:
+      body('M32 14 C46 14 56 26 56 40 C56 50 46 56 32 56 C18 56 8 50 8 40 C8 26 18 14 32 14 Z', '#B8F0D8') +
+      `<ellipse cx="32" cy="14" rx="7" ry="4" fill="#DDF8EC" stroke="${INK}" stroke-width="2"/>` +
+      `<ellipse cx="26" cy="24" rx="5" ry="2.5" fill="#fff" opacity=".7"/>` +
+      face(32, 36, 8, 'o'),
+  },
+  {
+    key: 'bee', color: '#FFB020',
+    svg:
+      `<ellipse cx="22" cy="20" rx="9" ry="6" fill="#DDEFFF" stroke="${INK}" stroke-width="2" opacity=".9"/><ellipse cx="42" cy="20" rx="9" ry="6" fill="#DDEFFF" stroke="${INK}" stroke-width="2" opacity=".9"/>` +
+      blob(32, 38, 22, 17, '#FFB020') +
+      `<path d="M14 30 q18 -6 36 0 M13 45 q19 6 38 0" stroke="${INK}" stroke-width="5" fill="none" stroke-linecap="round" opacity=".85"/>` +
+      `<path d="M26 22 L22 12 M38 22 L42 12" stroke="${INK}" stroke-width="2" stroke-linecap="round"/><circle cx="22" cy="12" r="2" fill="${INK}"/><circle cx="42" cy="12" r="2" fill="${INK}"/>` +
+      face(32, 37, 8, 'smile'),
+  },
+]
+
+export default {
+  pieces,
+  // a mystery friend: a lavender egg, still deciding who to be
+  hidden:
+    body('M32 8 C46 8 54 24 54 40 C54 52 44 58 32 58 C20 58 10 52 10 40 C10 24 18 8 32 8 Z', '#D9C7FF') +
+    `<path d="M27 26 Q27 19 32 19 Q37 19 37 25 Q37 29 33 30.5 L33 34" stroke="${INK}" stroke-width="3.4" fill="none" stroke-linecap="round"/>` +
+    `<circle cx="33" cy="40" r="2.2" fill="${INK}"/>` +
+    `<circle cx="20" cy="42" r="3" fill="#FF8FB1" opacity=".55"/><circle cx="44" cy="42" r="3" fill="#FF8FB1" opacity=".55"/>`,
+}

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -19,6 +19,7 @@
 import bolts from './skinart/bolts.js'
 import mine from './skinart/mine.js'
 import dash from './skinart/dash.js'
+import kawaii from './skinart/kawaii.js'
 
 // a LOOKS card: two of the skin's own pieces stacked, so the card is the skin
 const stack = (a, b) =>
@@ -55,6 +56,17 @@ export const SKINS = [
     preview:
       `<rect x="2" y="2" width="60" height="60" rx="6" fill="#141A2E"/>` +
       stack(dash.pieces[0].svg, dash.pieces[1].svg),
+  },
+  {
+    key: 'kawaii',
+    title: 'Kawaii Pop',
+    pieces: kawaii.pieces,
+    hidden: kawaii.hidden,
+    motion: { seconds: .5, lift: 1.4, spin: 0, stagger: .08, land: 'squish' },
+    sound: 'cute',
+    preview:
+      `<rect x="2" y="2" width="60" height="60" rx="14" fill="#FFE3EE"/>` +
+      stack(kawaii.pieces[0].svg, kawaii.pieces[2].svg),
   },
   {
     key: 'tubes',

--- a/src/lib/ui/flight.js
+++ b/src/lib/ui/flight.js
@@ -108,6 +108,17 @@ export function flightKeyframes(verb, { dx, dy, peakRel, rimRel, spin }) {
         { transform: 'translate(0px, -4px) rotate(0deg)', easing: 'ease-out', offset: 0.88 },
         { transform: 'translate(0px, 0px) rotate(0deg)', offset: 1 },
       ]
+    case 'squish':
+      // kawaii: crouch, spring, stretch through the hop, splat on landing and
+      // wobble back to round. the squash lives in scale, the trip in translate.
+      return [
+        { transform: `${start} rotate(0deg) scale(1,1)`, easing: 'ease-in', offset: 0 },
+        { transform: `${start} rotate(0deg) scale(1.22,.78)`, easing: 'cubic-bezier(.3,0,.5,1)', offset: 0.14 },
+        { transform: `${peak(0.5)} rotate(${spin * 0.5}deg) scale(.86,1.16)`, easing: CRUISE, offset: 0.5 },
+        { transform: `translate(0px, 0px) rotate(${end}deg) scale(1.28,.72)`, easing: 'ease-out', offset: 0.78 },
+        { transform: `translate(0px, -3px) rotate(0deg) scale(.94,1.08)`, easing: 'ease-in-out', offset: 0.9 },
+        { transform: `translate(0px, 0px) rotate(${end}deg) scale(1,1)`, offset: 1 },
+      ]
     case 'zig':
       return [
         { transform: `${start} rotate(0deg)`, easing: 'linear', offset: 0 },
@@ -153,6 +164,7 @@ export function landingTimes(motion, count, verb = motion.land) {
     fly: 1,
     hover: 0.88,
     zig: 1,
+    squish: 0.78,
     bounce: 0.78,
     slide: 0.92,
     zip: 1,

--- a/src/lib/ui/fx.js
+++ b/src/lib/ui/fx.js
@@ -40,6 +40,7 @@ const RECIPES = {
   slide: { n: 6, colors: ['#D8C4A6', '#B79A76', '#FFF3DD'], shape: 'chunk', speed: 90, up: .7, grav: 380, life: .26 },
   zip: { n: 9, colors: ['#3EF0D0', '#FF4FD8', '#FFFFFF'], shape: 'spark', speed: 170, up: .3, grav: 60, life: .22 },
   float: { n: 8, colors: ['#FFD7E8', '#BFE8FF', '#FFF6C9'], shape: 'dot', speed: 70, up: 1, grav: -60, life: .45 },
+  squish: { n: 9, colors: ['#FF8FB1', '#FFD7E8', '#FFFFFF'], shape: 'dot', speed: 85, up: 1.1, grav: -40, life: .5 },
 }
 
 function loop(now) {

--- a/src/lib/ui/sounds.js
+++ b/src/lib/ui/sounds.js
@@ -108,6 +108,14 @@ const MATERIALS = {
   pop(at, i) {
     tone({ freq: 340 + i * 30, glide: 150, type: 'sine', at, len: 0.14 })
   },
+  cute(at, i) {
+    // a squeak on the crouch, a "pomf" on the splat, a tiny rising chirp as
+    // it wobbles back: three beats that follow the squish keyframes
+    tone({ freq: 700 + i * 40, glide: 1100, type: 'sine', at: Math.max(0, at - 0.3), len: 0.07, vol: 0.06 })
+    noise({ at, len: 0.07, vol: 0.09, freq: 380, q: 0.5 })
+    tone({ freq: 520 + i * 40, glide: 780, type: 'triangle', at: at + 0.04, len: 0.1, vol: 0.1 })
+    tone({ freq: 1040 + i * 40, glide: 1400, type: 'sine', at: at + 0.11, len: 0.07, vol: 0.05 })
+  },
 }
 
 export const sound = {

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -10,9 +10,9 @@ let failures = 0
 const fail = msg => { failures += 1; console.error('FAIL ' + msg) }
 
 const GEO = { dx: -120, dy: 80, peakRel: -140, rimRel: -60 }
-const VERBS = new Set(['drop', 'screw', 'breakpop', 'flip', 'roll', 'fly', 'hover', 'zig'])
-const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop'])
-const CONVERSIONS = ['bolts', 'mine', 'dash', 'tubes']
+const VERBS = new Set(['drop', 'screw', 'breakpop', 'flip', 'roll', 'fly', 'hover', 'zig', 'squish'])
+const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop', 'cute'])
+const CONVERSIONS = ['bolts', 'mine', 'dash', 'kawaii', 'tubes']
 const CSS = readFileSync(new URL('../src/app.css', import.meta.url), 'utf8')
 
 const translateOf = transform => {
@@ -127,4 +127,4 @@ if (failures) {
   console.error(`${failures} conversion/flight problem(s)`)
   process.exit(1)
 }
-console.log(`flight ok: ${SKINS.length} conversions, ${VERBS.size} verbs, 36 custom pieces proven`)
+console.log(`flight ok: ${SKINS.length} conversions, ${VERBS.size} verbs, ${(SKINS.length - 1) * 12} custom pieces proven`)


### PR DESCRIPTION
the fifth total conversion. twelve tiny creatures (bun, kitty, froggy, bear, chick, piggy, whale, star, cloud, onigiri, mochi, bee), each a different silhouette so form sorts as well as colour. they move with a new `squish` verb: crouch, spring, stretch through the hop, splat on landing, wobble back to round. a `cute` sound material follows those beats (squeak, pomf, chirp) and a pastel sparkle burst on touchdown. the board is a pastel nursery with soft cups and a candy-striped floor.

gates: verify-flight now proves 5 conversions, 9 verbs, 48 custom pieces; copy lint clean; svelte-check 0/0; production build; driven in a real browser (skin applied, live animation mid-hop, fx canvas, zero console errors), frames reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG