### PR TITLE
bolts: nuts as three-quarter hex prisms that turn about the post (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -261,32 +261,44 @@ h1 {
   border-radius: 0;
   background: transparent;
 }
-[data-skin="bolts"] .tube::before { /* the shaft: lit steel, helical thread */
+[data-skin="bolts"] .tube::before { /* the threaded post, rounded at the top */
   content: '';
   position: absolute;
-  inset: 0 auto 5px 50%;
-  width: 12px;
+  inset: 0 auto 6px 50%;
+  width: 34%;
+  min-width: 14px;
   translate: -50% 0;
   background:
-    linear-gradient(90deg, rgb(255 255 255 / .55), rgb(255 255 255 / 0) 45%, rgb(0 0 0 / .25) 90%),
-    repeating-linear-gradient(-24deg, #C9C1B8 0 3px, #918880 3px 6px, #6E665F 6px 7px);
+    linear-gradient(90deg, rgb(255 255 255 / .6), rgb(255 255 255 / 0) 40%, rgb(0 0 0 / .3) 92%),
+    repeating-linear-gradient(180deg, #D3CCC4 0 3px, #8F877F 3px 5px, #6E665F 5px 6px);
   border: 2px solid var(--line);
   border-bottom: 0;
-  border-radius: 5px 5px 0 0;
-  box-shadow: 3px 0 5px -2px rgb(61 50 48 / .4);
+  border-radius: 45% 45% 0 0 / 22% 22% 0 0;
+  box-shadow: 4px 0 6px -3px rgb(61 50 48 / .45);
 }
-[data-skin="bolts"] .tube::after { /* the bolt head above the rim */
+[data-skin="bolts"] .tube::after { /* the washer the column stands on */
   content: '';
   position: absolute;
-  top: -7px; left: 50%;
-  width: 26px; height: 10px;
+  bottom: -4px; left: 50%;
+  width: 96%; height: 14px;
   translate: -50% 0;
-  background: linear-gradient(180deg, #E8E2DA, #A89F96);
+  background: radial-gradient(ellipse at 40% 35%, #E4DED7, #A29A92 70%, #7A736C);
   border: 2px solid var(--line);
-  border-radius: 4px;
+  border-radius: 50%;
 }
+[data-skin="bolts"] .tube { border-bottom-color: transparent; }
 [data-skin="bolts"] .item { position: relative; z-index: 1; padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
-[data-skin="bolts"] .item svg { scale: .96; }
+[data-skin="bolts"] .item svg { scale: 1.04; overflow: visible; }
+/* a flying nut TURNS about the bolt: its side-face band slides one full turn
+   (two periods of 52 svg units) across the flight, timed to the same seconds
+   and stagger delay the Board gave the trip, so the band ends where it began */
+[data-skin="bolts"] .item.flying .nut-band {
+  animation: nutspin var(--flight-secs, .5s) linear var(--flight-delay, 0s) 1;
+}
+@keyframes nutspin {
+  from { transform: translateX(0); }
+  to { transform: translateX(-104px); }
+}
 [data-skin="bolts"] .tube.sel { box-shadow: none; }
 
 /* block mine: a bright day over dug shafts. the pieces are 2.5d cubes with

--- a/src/lib/engine/skinart/bolts.js
+++ b/src/lib/engine/skinart/bolts.js
@@ -1,84 +1,96 @@
-// nuts & bolts pieces: twelve anodised hex nuts, face on, lit from the upper
-// left. the nut IS the piece (no theme face on top): colour carries identity,
-// and a small stamped mark on the crown carries it again for anyone who does
-// not read colour. drawn for a viewBox of 0 0 64 64.
+// nuts & bolts pieces: twelve coloured hex nuts seen in three-quarter view,
+// the way they sit on a real bolt: a lit top face with the bore showing,
+// then the side faces below it carrying a small white mark for anyone who
+// does not read colour. the nut IS the piece, no theme face on top.
+//
+// the side faces live in a wide band under a clip. app.css slides that band
+// sideways while a nut is flying, so a nut screwing down the post visibly
+// TURNS about the bolt instead of tumbling in the plane of the screen.
+// drawn for a viewBox of 0 0 64 64.
 //
 // every piece module in skinart/ exports the same shape:
 //   { pieces: [12 x { key, color, svg }], hidden: svg }
 
-const HEX = 'M32 4 L56 18 L56 46 L32 60 L8 46 L8 18 Z'
-const INNER = 'M32 11 L50 21.5 L50 42.5 L32 53 L14 42.5 L14 21.5 Z'
+// the flattened hexagon of the top face, and the body below it
+const TOP = 'M6 18 L20 8 L44 8 L58 18 L44 28 L20 28 Z'
+const BODY = 'M6 18 L6 50 L20 60 L44 60 L58 50 L58 18 L44 28 L20 28 Z'
+// one period of the band: a lit side face, the front face, a shaded side
+// face (14 + 24 + 14 = 52 units). a full turn of the nut is two periods.
+export const BAND_PERIOD = 52
 
-// the twelve stamped marks, each a tiny engraving centred at (32,32), drawn
-// in a darker shade of the nut so it reads as machined rather than painted
+// the twelve marks, each centred at (0,0) in a 16-unit box
 const MARKS = {
-  dot: 'M32 32 m-3 0 a3 3 0 1 0 6 0 a3 3 0 1 0 -6 0',
-  bar: 'M25 30 h14 v4 h-14 z',
-  plus: 'M30 25 h4 v5 h5 v4 h-5 v5 h-4 v-5 h-5 v-4 h5 z',
-  cross: 'M26 26 l3 -0.2 l3 3.2 l3 -3.2 l3 0.2 l-4.5 6 l4.5 6 l-3 0.2 l-3 -3.2 l-3 3.2 l-3 -0.2 l4.5 -6 z',
-  tri: 'M32 25 l7 12 h-14 z',
-  ring: 'M32 32 m-6 0 a6 6 0 1 0 12 0 a6 6 0 1 0 -12 0 z M32 32 m-3 0 a3 3 0 1 1 6 0 a3 3 0 1 1 -6 0 z',
-  square: 'M27 27 h10 v10 h-10 z',
-  star: 'M32 24 l2.4 5.2 l5.6 .6 l-4.2 3.8 l1.2 5.6 l-5 -2.9 l-5 2.9 l1.2 -5.6 l-4.2 -3.8 l5.6 -.6 z',
-  diamond: 'M32 25 l7 7 l-7 7 l-7 -7 z',
-  dots: 'M27 32 m-2.6 0 a2.6 2.6 0 1 0 5.2 0 a2.6 2.6 0 1 0 -5.2 0 M37 32 m-2.6 0 a2.6 2.6 0 1 0 5.2 0 a2.6 2.6 0 1 0 -5.2 0',
-  chevron: 'M25 30 l7 -6 l7 6 l-2.6 2.6 l-4.4 -3.8 l-4.4 3.8 z M25 37 l7 -6 l7 6 l-2.6 2.6 l-4.4 -3.8 l-4.4 3.8 z',
-  wave: 'M24 33 q4 -7 8 0 t8 0 l0 3.5 q-4 7 -8 0 t-8 0 z',
+  dot: 'M0 0 m-3.2 0 a3.2 3.2 0 1 0 6.4 0 a3.2 3.2 0 1 0 -6.4 0',
+  bar: 'M-6 -2 h12 v4 h-12 z',
+  plus: 'M-2 -6 h4 v4 h4 v4 h-4 v4 h-4 v-4 h-4 v-4 h4 z',
+  cross: 'M-5.5 -3.5 l2 -2 l3.5 3.5 l3.5 -3.5 l2 2 l-3.5 3.5 l3.5 3.5 l-2 2 l-3.5 -3.5 l-3.5 3.5 l-2 -2 l3.5 -3.5 z',
+  tri: 'M0 -6 l6.5 11 h-13 z',
+  ring: 'M0 0 m-6 0 a6 6 0 1 0 12 0 a6 6 0 1 0 -12 0 z M0 0 m-3 0 a3 3 0 1 1 6 0 a3 3 0 1 1 -6 0 z',
+  square: 'M-5 -5 h10 v10 h-10 z',
+  star: 'M0 -7 l2.1 4.5 l4.9 .5 l-3.7 3.3 l1.1 4.9 l-4.4 -2.6 l-4.4 2.6 l1.1 -4.9 l-3.7 -3.3 l4.9 -.5 z',
+  diamond: 'M0 -6.5 l6.5 6.5 l-6.5 6.5 l-6.5 -6.5 z',
+  dots: 'M-4.5 0 m-2.6 0 a2.6 2.6 0 1 0 5.2 0 a2.6 2.6 0 1 0 -5.2 0 M4.5 0 m-2.6 0 a2.6 2.6 0 1 0 5.2 0 a2.6 2.6 0 1 0 -5.2 0',
+  chevron: 'M-6 -1 l6 -5 l6 5 l-2.4 2.4 l-3.6 -3 l-3.6 3 z M-6 5 l6 -5 l6 5 l-2.4 2.4 l-3.6 -3 l-3.6 3 z',
+  heart: 'M0 6 C-7 1 -7 -6 -2.5 -6 C-1 -6 0 -5 0 -4 C0 -5 1 -6 2.5 -6 C7 -6 7 1 0 6 z',
 }
 
-// colour triples: face, lit edge, shadow edge. the twelve read apart on a
-// phone in sunlight, and no two share a hue family.
+// face, lit edge, shadow edge: the twelve read apart on a phone in sunlight
 const NUTS = [
-  ['red', '#E5484D', '#FF8A8E', '#8E2226', 'dot'],
-  ['blue', '#3B82F6', '#8DB8FF', '#1E3F8A', 'bar'],
-  ['gold', '#F0B429', '#FFE08A', '#8C6410', 'plus'],
-  ['green', '#46A758', '#93D9A0', '#1F5A2B', 'cross'],
-  ['violet', '#8E4EC6', '#C9A0EA', '#4A2470', 'tri'],
-  ['orange', '#F76B15', '#FFA96B', '#8A3A08', 'ring'],
-  ['teal', '#12A594', '#7DD9CD', '#085C52', 'square'],
-  ['pink', '#E93D82', '#FF9CC4', '#821E47', 'star'],
-  ['brown', '#A0704A', '#D4AC88', '#5A3B24', 'diamond'],
-  ['sky', '#5BB8F5', '#B3E1FF', '#2A6A96', 'dots'],
-  ['lime', '#9BC53D', '#D3EB8F', '#557020', 'chevron'],
-  ['plum', '#5C3B8C', '#A98AD1', '#2C1A48', 'wave'],
+  ['red', '#E5484D', '#FF8A8E', '#9C2A2E', 'tri'],
+  ['blue', '#3B82F6', '#8DB8FF', '#234A9C', 'plus'],
+  ['gold', '#F0B429', '#FFE08A', '#A0721A', 'diamond'],
+  ['green', '#46A758', '#93D9A0', '#27683A', 'dot'],
+  ['violet', '#8E4EC6', '#C9A0EA', '#563087', 'star'],
+  ['orange', '#F76B15', '#FFA96B', '#A3450C', 'square'],
+  ['teal', '#12A594', '#7DD9CD', '#0B6C61', 'ring'],
+  ['pink', '#E93D82', '#FF9CC4', '#9A2656', 'heart'],
+  ['brown', '#A0704A', '#D4AC88', '#66472E', 'bar'],
+  ['sky', '#5BB8F5', '#B3E1FF', '#3479A6', 'dots'],
+  ['lime', '#9BC53D', '#D3EB8F', '#648228', 'chevron'],
+  ['slate', '#5F6B7A', '#A2AFBF', '#3A424D', 'cross'],
 ]
 
 function nut(key, face, lit, shade, mark) {
-  const g = `bolt-${key}`
+  const id = `nut-${key}`
+  // one period of side faces; the mark rides the front face only
+  const period = (x) =>
+    `<rect x="${x}" y="18" width="14" height="42" fill="${lit}"/>` +
+    `<rect x="${x + 14}" y="18" width="24" height="42" fill="${face}"/>` +
+    `<rect x="${x + 38}" y="18" width="14" height="42" fill="${shade}"/>` +
+    `<path d="${MARKS[mark]}" fill="#fff" opacity=".92" transform="translate(${x + 26} 42)"/>`
   return (
     `<defs>` +
-    `<linearGradient id="${g}-f" x1="0" y1="0" x2="1" y2="1">` +
-    `<stop offset="0" stop-color="${lit}"/><stop offset=".45" stop-color="${face}"/><stop offset="1" stop-color="${shade}"/>` +
+    `<clipPath id="${id}-c"><path d="${BODY}"/></clipPath>` +
+    `<linearGradient id="${id}-t" x1="0" y1="0" x2="1" y2="1">` +
+    `<stop offset="0" stop-color="#fff" stop-opacity=".85"/><stop offset=".5" stop-color="${lit}"/><stop offset="1" stop-color="${face}"/>` +
     `</linearGradient>` +
-    `<linearGradient id="${g}-c" x1="0" y1="0" x2="1" y2="1">` +
-    `<stop offset="0" stop-color="${face}"/><stop offset="1" stop-color="${lit}"/>` +
-    `</linearGradient>` +
-    `<radialGradient id="${g}-b" cx=".4" cy=".35" r=".7">` +
-    `<stop offset="0" stop-color="#6E665F"/><stop offset=".6" stop-color="#3A3430"/><stop offset="1" stop-color="#1E1B19"/>` +
-    `</radialGradient>` +
     `</defs>` +
-    // the outer hex body, bevelled by the diagonal gradient
-    `<path d="${HEX}" fill="url(#${g}-f)" stroke="#2A2220" stroke-width="2.5" stroke-linejoin="round"/>` +
-    // the crown: a flatter inner hex catching the light
-    `<path d="${INNER}" fill="url(#${g}-c)" stroke="${shade}" stroke-width="1.5" stroke-linejoin="round" opacity=".95"/>` +
-    // the stamped mark, engraved into the crown
-    `<path d="${MARKS[mark]}" fill="#1E1B19" opacity=".8" transform="translate(0 -12.5) scale(.95) translate(1.7 1.7)"/>` +
-    // the threaded bore
-    `<circle cx="32" cy="36" r="9.5" fill="url(#${g}-b)" stroke="#1E1B19" stroke-width="1.5"/>` +
-    `<circle cx="32" cy="36" r="6.5" fill="none" stroke="#8C847C" stroke-width="1.2" stroke-dasharray="2.2 1.6" opacity=".8"/>` +
-    // one specular glint on the upper-left flat
-    `<path d="M12 20 L30 9 L30 12 L14 22 Z" fill="#fff" opacity=".45"/>`
+    // the side faces: a band three periods wide, clipped to the body. the
+    // band starts one period left so the front face sits centre at rest.
+    `<g clip-path="url(#${id}-c)">` +
+    `<g class="nut-band">${period(-46)}${period(6)}${period(58)}</g>` +
+    // the bottom bevel and a soft vertical shading over the whole body
+    `<path d="M6 44 L6 50 L20 60 L44 60 L58 50 L58 44 L44 54 L20 54 Z" fill="#000" opacity=".22"/>` +
+    `<rect x="6" y="18" width="52" height="42" fill="url(#${id}-v)"/>` +
+    `</g>` +
+    `<defs><linearGradient id="${id}-v" x1="0" y1="0" x2="0" y2="1">` +
+    `<stop offset="0" stop-color="#fff" stop-opacity=".18"/><stop offset=".5" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity=".18"/>` +
+    `</linearGradient></defs>` +
+    // the top face, lit from the upper left, and the threaded bore
+    `<path d="${TOP}" fill="url(#${id}-t)"/>` +
+    `<ellipse cx="32" cy="18" rx="9.5" ry="4.6" fill="#2E2A27"/>` +
+    `<ellipse cx="32" cy="17.4" rx="7" ry="3.2" fill="none" stroke="#8C847C" stroke-width="1" stroke-dasharray="2 1.4" opacity=".7"/>` +
+    // the edges
+    `<path d="${TOP}" fill="none" stroke="#2A2220" stroke-width="2" stroke-linejoin="round"/>` +
+    `<path d="M6 18 L6 50 L20 60 L44 60 L58 50 L58 18" fill="none" stroke="#2A2220" stroke-width="2.2" stroke-linejoin="round"/>` +
+    `<path d="M20 28 L20 60 M44 28 L44 60" stroke="#2A2220" stroke-width="1.2" opacity=".55"/>`
   )
 }
 
 export default {
   pieces: NUTS.map(([key, face, lit, shade, mark]) => ({ key: `${key} nut`, color: face, svg: nut(key, face, lit, shade, mark) })),
-  // a mystery nut: dull unfinished steel with a question stamp
-  hidden:
-    `<defs><linearGradient id="bolt-hid" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#D9D3CC"/><stop offset=".5" stop-color="#A39B93"/><stop offset="1" stop-color="#5E5751"/></linearGradient></defs>` +
-    `<path d="${HEX}" fill="url(#bolt-hid)" stroke="#2A2220" stroke-width="2.5" stroke-linejoin="round"/>` +
-    `<path d="${INNER}" fill="#B5ADA5" stroke="#5E5751" stroke-width="1.5" stroke-linejoin="round"/>` +
-    `<path d="M27 25 Q27 19 32 19 Q37 19 37 24 Q37 28 33 29.5 L33 32" stroke="#4A433D" stroke-width="3" fill="none" stroke-linecap="round"/>` +
-    `<circle cx="33" cy="36.5" r="1.8" fill="#4A433D"/>` +
-    `<circle cx="32" cy="45" r="5" fill="#3A3430" stroke="#1E1B19" stroke-width="1.5"/>`,
+  // a mystery nut: dull unfinished steel, a question mark on the front face
+  hidden: nut('hid', '#A39B93', '#D9D3CC', '#5E5751', 'dot')
+    .replace(/<path d="[^"]*" fill="#fff" opacity="\.92" transform="translate\(32 42\)"\/>/,
+      `<path d="M-4 -5 Q-4 -10 0 -10 Q4 -10 4 -6 Q4 -3 1 -2 L1 0" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" transform="translate(32 42)"/><circle cx="33" cy="46" r="1.6" fill="#fff"/>`),
 }

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -31,7 +31,9 @@ export const SKINS = [
     title: 'Nuts & Bolts',
     pieces: bolts.pieces,
     hidden: bolts.hidden,
-    motion: { seconds: .56, lift: 1.25, spin: -720, stagger: .08, land: 'screw' },
+    // spin 0: the nut turns about the bolt via its own side band (app.css
+    // nutspin), a planar rotate would read as tumbling in three-quarter view
+    motion: { seconds: .6, lift: 1.25, spin: 0, stagger: .09, land: 'screw' },
     sound: 'metal',
     preview:
       `<rect x="29" y="2" width="6" height="60" fill="#B9AFA6" stroke="#2A2220" stroke-width="2"/>` +

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -108,6 +108,9 @@
       for (const a of node.getAnimations()) a.cancel()
       node.style.transformOrigin = ['screw', 'roll', 'breakpop'].includes(verb) ? '50% 50%' : '50% 80%'
       node.dataset.flightSeq = flightSeq
+      // css-side companions (a nut's turning band) sync to the same clock
+      node.style.setProperty('--flight-secs', `${motion.seconds}s`)
+      node.style.setProperty('--flight-delay', `${index * (motion.stagger ?? 0)}s`)
       node.classList.add('flying')
       const burst = index < 4 // a long convoy bursts only its head, not 7 puffs
       const options = flightOptions(motion, index)


### PR DESCRIPTION
the nuts were face-on hexes, which read sideways on a vertical bolt. now each nut is a hex prism in three-quarter view: a lit top face with the bore showing, side faces below carrying a small white mark. the side faces live in a wide band under a clip, and while a nut is flying that band slides one full turn on the same clock as the flight, so a nut screwing down the post visibly turns about the bolt instead of tumbling in the plane of the screen. the post is a rounded threaded cylinder standing on a washer.

gates: verify-flight (5 conversions, 9 verbs, 48 pieces), copy lint, svelte-check 0/0, production build, real-browser drive with frames reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG