### PR TITLE
change the look mid-level from the in-game bar (refs #29)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -174,6 +174,10 @@
   <main class="screen" id="game">
     <header class="bar">
       <span class="chip flat" id="board-label">{store.boardLabel}</span>
+      <!-- looks are swappable mid-level: the store drops any in-flight cue on a
+           skin change, and the board, moves, and clock are untouched. it sits
+           before the readouts so it never crowds the version stamp top-right. -->
+      <button class="chip" onclick={() => store.openDialog('looks')} aria-label="Change the look"><span aria-hidden="true">&#10024;</span></button>
       <span class="chip flat mono" aria-label="time elapsed">{store.clock}</span>
       <span class="chip flat mono" aria-live="polite">{store.moves} {store.moves === 1 ? 'move' : 'moves'}</span>
     </header>


### PR DESCRIPTION
a looks chip in the in-game header opens the same picker as the menu, so a look can change mid-level without leaving. the store already drops any in-flight cue on a skin change; the board, move count, and clock are untouched. placed before the readouts so it never crowds the version stamp.

proof: real-browser drive plays a move, swaps bolts to mine from the chip, and asserts the move count and tube shape survive, the game screen stays up, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG