### PR TITLE
dice table: twelve polyhedral dice told apart by shape, colour, and material (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -364,6 +364,25 @@ h1 {
 [data-skin="kawaii"] .tube.sel { box-shadow: 0 .35rem 0 #E8A9C4; }
 [data-skin="kawaii"] .tube.done { box-shadow: 0 0 0 3px #FF8FB1, 0 0 16px 4px rgb(255 143 177 / .55); }
 
+/* dice table: green felt under a warm lamp, wooden dice trays, the dice carry
+   their own materials. */
+#board[data-skin="dice"] {
+  background:
+    radial-gradient(ellipse at 50% 20%, rgb(255 240 200 / .22), transparent 55%),
+    repeating-radial-gradient(circle at 30% 70%, rgb(0 0 0 / .05) 0 2px, transparent 2px 5px),
+    #1F6B45 !important;
+}
+[data-skin="dice"] .tube {
+  border: .22rem solid #7A4E2A;
+  border-radius: .7rem;
+  background: linear-gradient(180deg, rgb(0 0 0 / .18), rgb(0 0 0 / .32));
+  box-shadow: inset 0 3px 6px rgb(0 0 0 / .45), inset 0 -2px 0 rgb(255 255 255 / .08), 0 4px 6px -3px rgb(0 0 0 / .5);
+}
+[data-skin="dice"] .item { padding: 0; filter: drop-shadow(0 3px 2px rgb(0 0 0 / .45)); }
+[data-skin="dice"] .item svg { scale: .96; }
+[data-skin="dice"] .tube.sel { box-shadow: inset 0 3px 6px rgb(0 0 0 / .45), 0 .35rem 0 #4A2E17; }
+[data-skin="dice"] .tube.done { box-shadow: 0 0 0 3px #FFD54A, 0 0 16px 4px rgb(255 213 74 / .55); }
+
 /* the selected lift and done cues stay identical across skins on purpose:
    the READING of the board never changes, only its world */
 

--- a/src/lib/engine/skinart/dice.js
+++ b/src/lib/engine/skinart/dice.js
@@ -1,0 +1,141 @@
+// dice pieces: twelve polyhedral dice (d4 to d20), each set told apart by its
+// shape, its colour, and its material (marble, speckle, glitter, metal,
+// glass, pearl). no numbers on the faces: form and finish carry identity,
+// which also keeps them readable at 40px. lit from the upper left so every
+// die reads as a solid. viewBox 0 0 64 64.
+//
+// exports { pieces: [12 x { key, color, svg }], hidden: svg }
+
+const INK = '#2A2220'
+const C = { x: 32, y: 33 }
+
+const pt = (r, deg) => [C.x + r * Math.cos(deg * Math.PI / 180), C.y + r * Math.sin(deg * Math.PI / 180)]
+const poly = pts => pts.map(([x, y]) => `${x.toFixed(1)} ${y.toFixed(1)}`).join(' ')
+const centroid = pts => pts.reduce((a, [x, y]) => [a[0] + x / pts.length, a[1] + y / pts.length], [0, 0])
+
+// a shape is its silhouette plus its visible faces. faces get their shade
+// from where they sit: up and left is lit, down and right is shadow.
+const SHAPES = {
+  d4() {
+    const a = [32, 6], b = [58, 54], c = [6, 54], m = [32, 36]
+    return { outline: [a, b, c], faces: [[a, m, c], [a, b, m], [c, m, b]] }
+  },
+  d6() {
+    const t = [[32, 7], [57, 20], [32, 33], [7, 20]]
+    const l = [[7, 20], [32, 33], [32, 59], [7, 46]]
+    const r = [[32, 33], [57, 20], [57, 46], [32, 59]]
+    return { outline: [[32, 7], [57, 20], [57, 46], [32, 59], [7, 46], [7, 20]], faces: [t, l, r] }
+  },
+  d8() {
+    const n = [32, 5], e = [59, 33], s = [32, 61], w = [5, 33], m = [32, 33]
+    return { outline: [n, e, s, w], faces: [[n, m, w], [n, e, m], [w, m, s], [m, e, s]] }
+  },
+  d10() {
+    const top = [32, 4], l = [7, 25], r = [57, 25], bl = [14, 60], br = [50, 60], il = [19, 28], ir = [45, 28], m = [32, 47]
+    return {
+      outline: [top, r, br, bl, l],
+      faces: [[top, ir, m, il], [top, il, bl, l], [top, r, br, ir], [il, m, ir, br, bl]],
+    }
+  },
+  d12() {
+    const outer = Array.from({ length: 10 }, (_, i) => pt(28, -90 + i * 36))
+    const inner = Array.from({ length: 5 }, (_, i) => pt(13, -90 + i * 72))
+    const faces = [inner]
+    for (let i = 0; i < 5; i++) {
+      const a = inner[i], b = inner[(i + 1) % 5]
+      faces.push([a, outer[(i * 2) % 10], outer[(i * 2 + 1) % 10], outer[(i * 2 + 2) % 10], b])
+    }
+    return { outline: outer, faces }
+  },
+  d20() {
+    const outer = Array.from({ length: 6 }, (_, i) => pt(29, -90 + i * 60))
+    const inner = Array.from({ length: 3 }, (_, i) => pt(15, -90 + i * 120))
+    const faces = [inner]
+    for (let i = 0; i < 3; i++) {
+      const a = inner[i], b = inner[(i + 1) % 3]
+      const oa = outer[i * 2], om = outer[i * 2 + 1], ob = outer[(i * 2 + 2) % 6]
+      faces.push([a, oa, om], [a, om, b], [b, om, ob])
+    }
+    return { outline: outer, faces }
+  },
+}
+
+// materials: a defs block and an overlay painted over the whole silhouette
+const MATERIALS = {
+  marble: (id, color) => ({
+    defs: '',
+    over: `<g opacity=".55" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round"><path d="M10 40 q10 -14 22 -6 t20 -12"/><path d="M16 54 q8 -6 14 -2 t14 -10"/></g><g opacity=".22" fill="none" stroke="#000" stroke-width="1.4"><path d="M12 26 q12 6 20 -2 t22 4"/></g>`,
+  }),
+  speckle: () => ({
+    defs: '',
+    over: `<g fill="#fff" opacity=".8">${[[14, 22], [24, 14], [40, 12], [50, 24], [20, 36], [36, 30], [48, 42], [16, 50], [30, 46], [44, 54], [26, 56], [54, 36]].map(([x, y]) => `<circle cx="${x}" cy="${y}" r="1.3"/>`).join('')}</g><g fill="#000" opacity=".35">${[[20, 26], [44, 20], [32, 40], [50, 48], [22, 46], [38, 56]].map(([x, y]) => `<circle cx="${x}" cy="${y}" r="1"/>`).join('')}</g>`,
+  }),
+  glitter: () => ({
+    defs: '',
+    over: `<g fill="#fff" opacity=".9">${[[16, 24], [28, 12], [42, 16], [50, 30], [22, 40], [36, 34], [46, 46], [18, 52], [32, 52], [52, 54]].map(([x, y]) => `<path d="M${x} ${y - 2.6} l.8 1.8 l1.8 .8 l-1.8 .8 l-.8 1.8 l-.8 -1.8 l-1.8 -.8 l1.8 -.8 z"/>`).join('')}</g>`,
+  }),
+  metal: (id) => ({
+    defs: `<linearGradient id="${id}-m" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#fff" stop-opacity=".7"/><stop offset=".35" stop-color="#fff" stop-opacity=".05"/><stop offset=".5" stop-color="#000" stop-opacity=".18"/><stop offset=".7" stop-color="#fff" stop-opacity=".25"/><stop offset="1" stop-color="#000" stop-opacity=".35"/></linearGradient>`,
+    over: `<rect x="0" y="0" width="64" height="64" fill="url(#${id}-m)"/>`,
+  }),
+  glass: (id) => ({
+    defs: `<radialGradient id="${id}-g" cx=".32" cy=".25" r=".7"><stop offset="0" stop-color="#fff" stop-opacity=".85"/><stop offset=".4" stop-color="#fff" stop-opacity=".12"/><stop offset="1" stop-color="#000" stop-opacity=".22"/></radialGradient>`,
+    over: `<rect x="0" y="0" width="64" height="64" fill="url(#${id}-g)"/>`,
+  }),
+  pearl: (id) => ({
+    defs: `<linearGradient id="${id}-p" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#FFD6E8" stop-opacity=".8"/><stop offset=".35" stop-color="#D6F0FF" stop-opacity=".7"/><stop offset=".7" stop-color="#E6FFE0" stop-opacity=".7"/><stop offset="1" stop-color="#FFF3C9" stop-opacity=".8"/></linearGradient>`,
+    over: `<rect x="0" y="0" width="64" height="64" fill="url(#${id}-p)"/>`,
+  }),
+}
+
+function die(key, shape, color, material) {
+  const id = `die-${key}`
+  const { outline, faces } = SHAPES[shape]()
+  const mat = MATERIALS[material](id, color)
+  const silhouette = `<polygon points="${poly(outline)}"/>`
+  // face shading from position: up-left brightens, down-right darkens
+  const shaded = faces.map(f => {
+    const [cx, cy] = centroid(f)
+    const light = ((C.x - cx) + (C.y - cy)) / 40 // -1 .. 1
+    const fill = light >= 0 ? `#fff` : `#000`
+    const opacity = Math.min(0.42, Math.abs(light) * 0.42 + 0.04).toFixed(2)
+    return `<polygon points="${poly(f)}" fill="${fill}" opacity="${opacity}"/>`
+  }).join('')
+  const edges = faces.map(f => `<polygon points="${poly(f)}" fill="none" stroke="${INK}" stroke-width="1.1" stroke-linejoin="round" opacity=".55"/>`).join('')
+  return (
+    `<defs><clipPath id="${id}-c">${silhouette}</clipPath>${mat.defs}</defs>` +
+    `<g clip-path="url(#${id}-c)">` +
+    `<rect x="0" y="0" width="64" height="64" fill="${color}"/>` +
+    shaded +
+    mat.over +
+    `</g>` +
+    edges +
+    `<polygon points="${poly(outline)}" fill="none" stroke="${INK}" stroke-width="2.4" stroke-linejoin="round"/>`
+  )
+}
+
+const SETS = [
+  ['ruby d4', 'd4', '#D6323C', 'marble'],
+  ['ivory d6', 'd6', '#F1E6CC', 'speckle'],
+  ['sapphire d8', 'd8', '#2F6FE0', 'glass'],
+  ['emerald d10', 'd10', '#2FA35C', 'glitter'],
+  ['amethyst d12', 'd12', '#8A4DD0', 'marble'],
+  ['obsidian d20', 'd20', '#2B2B33', 'glitter'],
+  ['sunset d6', 'd6', '#F4772E', 'glass'],
+  ['pearl d20', 'd20', '#E9EEF5', 'pearl'],
+  ['bronze d8', 'd8', '#B0703A', 'metal'],
+  ['teal d12', 'd12', '#1FA6A0', 'speckle'],
+  ['gold d4', 'd4', '#E8B72C', 'metal'],
+  ['rose d10', 'd10', '#F06AA8', 'glitter'],
+]
+
+export default {
+  pieces: SETS.map(([key, shape, color, material]) => ({ key, color, svg: die(key.replace(/\s+/g, '-'), shape, color, material) })),
+  // a mystery die: a cloth dice bag, still closed
+  hidden:
+    `<path d="M22 22 Q32 14 42 22 L50 52 Q32 62 14 52 Z" fill="#7A5C8E" stroke="${INK}" stroke-width="2.4" stroke-linejoin="round"/>` +
+    `<path d="M20 24 Q32 30 44 24" stroke="${INK}" stroke-width="2.2" fill="none" stroke-linecap="round"/>` +
+    `<path d="M24 20 Q32 10 40 20" stroke="#C9A96A" stroke-width="3" fill="none" stroke-linecap="round"/>` +
+    `<path d="M28 36 Q28 31 32 31 Q36 31 36 35 Q36 38 33 39 L33 41.5" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round"/>` +
+    `<circle cx="33" cy="46" r="1.6" fill="#fff"/>`,
+}

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -20,6 +20,7 @@ import bolts from './skinart/bolts.js'
 import mine from './skinart/mine.js'
 import dash from './skinart/dash.js'
 import kawaii from './skinart/kawaii.js'
+import dice from './skinart/dice.js'
 
 // a LOOKS card: two of the skin's own pieces stacked, so the card is the skin
 const stack = (a, b) =>
@@ -69,6 +70,17 @@ export const SKINS = [
     preview:
       `<rect x="2" y="2" width="60" height="60" rx="14" fill="#FFE3EE"/>` +
       stack(kawaii.pieces[0].svg, kawaii.pieces[2].svg),
+  },
+  {
+    key: 'dice',
+    title: 'Dice Table',
+    pieces: dice.pieces,
+    hidden: dice.hidden,
+    motion: { seconds: .52, lift: 1.2, spin: 720, stagger: .07, land: 'tumble' },
+    sound: 'dice',
+    preview:
+      `<rect x="2" y="2" width="60" height="60" rx="10" fill="#1F6B45"/>` +
+      stack(dice.pieces[5].svg, dice.pieces[0].svg),
   },
   {
     key: 'tubes',

--- a/src/lib/ui/flight.js
+++ b/src/lib/ui/flight.js
@@ -119,6 +119,16 @@ export function flightKeyframes(verb, { dx, dy, peakRel, rimRel, spin }) {
         { transform: `translate(0px, -3px) rotate(0deg) scale(.94,1.08)`, easing: 'ease-in-out', offset: 0.9 },
         { transform: `translate(0px, 0px) rotate(${end}deg) scale(1,1)`, offset: 1 },
       ]
+    case 'tumble':
+      // dice: thrown in a spinning arc, hit the felt, skip once, settle
+      return [
+        { transform: `${start} rotate(0deg) scale(1,1)`, easing: LAUNCH, offset: 0 },
+        { transform: `${peak(0.5)} rotate(${spin * 0.45}deg) scale(1,1)`, easing: 'cubic-bezier(.4,0,.9,.6)', offset: 0.42 },
+        { transform: `translate(0px, 0px) rotate(${spin * 0.8}deg) scale(1.1,.88)`, easing: 'ease-out', offset: 0.66 },
+        { transform: `translate(0px, -7px) rotate(${spin * 0.92}deg) scale(.96,1.04)`, easing: 'ease-in', offset: 0.8 },
+        { transform: `translate(0px, 0px) rotate(${end}deg) scale(1.05,.94)`, easing: 'ease-out', offset: 0.9 },
+        { transform: `translate(0px, 0px) rotate(${end}deg) scale(1,1)`, offset: 1 },
+      ]
     case 'zig':
       return [
         { transform: `${start} rotate(0deg)`, easing: 'linear', offset: 0 },
@@ -165,6 +175,7 @@ export function landingTimes(motion, count, verb = motion.land) {
     hover: 0.88,
     zig: 1,
     squish: 0.78,
+    tumble: 0.66,
     bounce: 0.78,
     slide: 0.92,
     zip: 1,

--- a/src/lib/ui/fx.js
+++ b/src/lib/ui/fx.js
@@ -41,6 +41,7 @@ const RECIPES = {
   zip: { n: 9, colors: ['#3EF0D0', '#FF4FD8', '#FFFFFF'], shape: 'spark', speed: 170, up: .3, grav: 60, life: .22 },
   float: { n: 8, colors: ['#FFD7E8', '#BFE8FF', '#FFF6C9'], shape: 'dot', speed: 70, up: 1, grav: -60, life: .45 },
   squish: { n: 9, colors: ['#FF8FB1', '#FFD7E8', '#FFFFFF'], shape: 'dot', speed: 85, up: 1.1, grav: -40, life: .5 },
+  tumble: { n: 8, colors: ['#FFF3C9', '#FFD54A', '#FFFFFF'], shape: 'spark', speed: 120, up: .5, grav: 300, life: .26 },
 }
 
 function loop(now) {

--- a/src/lib/ui/sounds.js
+++ b/src/lib/ui/sounds.js
@@ -108,6 +108,14 @@ const MATERIALS = {
   pop(at, i) {
     tone({ freq: 340 + i * 30, glide: 150, type: 'sine', at, len: 0.14 })
   },
+  dice(at, i) {
+    // the clatter: a hard knock on the felt, a skip, and a settle click,
+    // timed to the tumble keyframes (hit at the beat, skip lands ~.12s later)
+    noise({ at, len: 0.05, vol: 0.12, freq: 2600 + i * 200, q: 2.5 })
+    tone({ freq: 240, glide: 150, type: 'triangle', at, len: 0.07, vol: 0.09 })
+    noise({ at: at + 0.12, len: 0.04, vol: 0.08, freq: 3200, q: 3 })
+    noise({ at: at + 0.18, len: 0.03, vol: 0.05, freq: 3800, q: 3 })
+  },
   cute(at, i) {
     // a squeak on the crouch, a "pomf" on the splat, a tiny rising chirp as
     // it wobbles back: three beats that follow the squish keyframes

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -10,9 +10,9 @@ let failures = 0
 const fail = msg => { failures += 1; console.error('FAIL ' + msg) }
 
 const GEO = { dx: -120, dy: 80, peakRel: -140, rimRel: -60 }
-const VERBS = new Set(['drop', 'screw', 'breakpop', 'flip', 'roll', 'fly', 'hover', 'zig', 'squish'])
-const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop', 'cute'])
-const CONVERSIONS = ['bolts', 'mine', 'dash', 'kawaii', 'tubes']
+const VERBS = new Set(['drop', 'screw', 'breakpop', 'flip', 'roll', 'fly', 'hover', 'zig', 'squish', 'tumble'])
+const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop', 'cute', 'dice'])
+const CONVERSIONS = ['bolts', 'mine', 'dash', 'kawaii', 'dice', 'tubes']
 const CSS = readFileSync(new URL('../src/app.css', import.meta.url), 'utf8')
 
 const translateOf = transform => {


### PR DESCRIPTION
the sixth total conversion. twelve dice from d4 to d20, each set told apart by its shape, its colour, and its material (marble, speckle, glass, glitter, metal, pearl), no numbers on any face. faces are shaded from their position so every die reads as a solid. they move with a `tumble` verb (spinning arc, hit the felt, one skip, settle) and a `dice` sound (knock, skip, settle click) on those beats. the board is green felt under a warm lamp with wooden dice trays; the mystery piece is a closed dice bag.

gates: verify-flight (6 conversions, 10 verbs, 60 pieces), copy lint, svelte-check 0/0, production build, real-browser drive plus a full piece sheet reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG