### PR TITLE
bolts thread onto the rod; the mined move gets a pickaxe and a carrier (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -261,20 +261,22 @@ h1 {
   border-radius: 0;
   background: transparent;
 }
-[data-skin="bolts"] .tube::before { /* the threaded post, rounded at the top */
+/* the bolt: a straight threaded rod, flat on top (a bolt, not a screw), as
+   wide as the nut's bore so the rod segment drawn inside the top nut lines
+   up with it. the thread pitch is 6/64 of a side, the same as the nut's. */
+[data-skin="bolts"] .tube::before {
   content: '';
   position: absolute;
   inset: 0 auto 6px 50%;
-  width: 34%;
-  min-width: 14px;
+  width: calc(var(--side, 44px) * 19 / 64);
   translate: -50% 0;
   background:
-    linear-gradient(90deg, rgb(255 255 255 / .6), rgb(255 255 255 / 0) 40%, rgb(0 0 0 / .3) 92%),
-    repeating-linear-gradient(180deg, #D3CCC4 0 3px, #8F877F 3px 5px, #6E665F 5px 6px);
+    linear-gradient(90deg, rgb(255 255 255 / .6), rgb(255 255 255 / 0) 40%, rgb(0 0 0 / .32) 100%),
+    repeating-linear-gradient(180deg, #D3CCC4 0 calc(var(--side, 44px) * 3 / 64), #8F877F calc(var(--side, 44px) * 3 / 64) calc(var(--side, 44px) * 5 / 64), #6E665F calc(var(--side, 44px) * 5 / 64) calc(var(--side, 44px) * 6 / 64));
   border: 2px solid var(--line);
   border-bottom: 0;
-  border-radius: 45% 45% 0 0 / 22% 22% 0 0;
-  box-shadow: 4px 0 6px -3px rgb(61 50 48 / .45);
+  border-radius: 50% 50% 0 0 / 6px 6px 0 0;
+  box-shadow: 4px 0 6px -3px rgb(61 50 48 / .45), inset 0 3px 0 rgb(255 255 255 / .35);
 }
 [data-skin="bolts"] .tube::after { /* the washer the column stands on */
   content: '';
@@ -289,6 +291,10 @@ h1 {
 [data-skin="bolts"] .tube { border-bottom-color: transparent; }
 [data-skin="bolts"] .item { position: relative; z-index: 1; padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
 [data-skin="bolts"] .item svg { scale: 1.04; overflow: visible; }
+/* the rod rises out of the TOP nut's bore, and out of a nut in flight, so the
+   bolt passes through the nut. a buried nut has the nut above covering it. */
+[data-skin="bolts"] .item:last-child .nut-rod,
+[data-skin="bolts"] .item.flying .nut-rod { display: block; }
 /* a flying nut TURNS about the bolt: its side-face band slides one full turn
    (two periods of 52 svg units) across the flight, timed to the same seconds
    and stagger delay the Board gave the trip, so the band ends where it began */
@@ -322,6 +328,15 @@ h1 {
 }
 [data-skin="mine"] .item svg { scale: .96; overflow: visible; image-rendering: pixelated; }
 [data-skin="mine"] .tube.done { box-shadow: 0 0 0 3px #8FCC5E, 0 0 16px 4px rgb(143 204 94 / .55); }
+
+/* actors perform a move on top of the board (actors.js). the layer covers
+   the board, never catches taps, and rides above a flying piece. */
+#board { position: relative; }
+.actor-layer { position: absolute; inset: 0; z-index: 31; pointer-events: none; overflow: visible; }
+.actor { position: absolute; will-change: transform, opacity; }
+.actor svg { display: block; width: 100%; height: 100%; overflow: visible; }
+.actor.pickaxe { transform-origin: 6% 94%; filter: drop-shadow(0 2px 2px rgb(0 0 0 / .4)); }
+.actor.visitor { filter: drop-shadow(0 4px 3px rgb(0 0 0 / .45)); }
 
 /* neon dash: dark grid, glowing lanes, icons with their own glow. an
    aesthetic tribute. */

--- a/src/lib/engine/skinart/bolts.js
+++ b/src/lib/engine/skinart/bolts.js
@@ -83,7 +83,20 @@ function nut(key, face, lit, shade, mark) {
     // the edges
     `<path d="${TOP}" fill="none" stroke="#2A2220" stroke-width="2" stroke-linejoin="round"/>` +
     `<path d="M6 18 L6 50 L20 60 L44 60 L58 50 L58 18" fill="none" stroke="#2A2220" stroke-width="2.2" stroke-linejoin="round"/>` +
-    `<path d="M20 28 L20 60 M44 28 L44 60" stroke="#2A2220" stroke-width="1.2" opacity=".55"/>`
+    `<path d="M20 28 L20 60 M44 28 L44 60" stroke="#2A2220" stroke-width="1.2" opacity=".55"/>` +
+    // the rod rising out of the bore. hidden on nuts buried in a stack (the
+    // nut above covers it) and shown by app.css on the top nut and on a nut in
+    // flight, so the bolt visibly passes THROUGH the nut instead of stopping
+    // at it. same width as the bore, same thread pitch as the css post.
+    `<g class="nut-rod" display="none">` +
+    `<rect x="22.5" y="-30" width="19" height="48" fill="url(#${id}-r)"/>` +
+    `<rect x="22.5" y="-30" width="19" height="48" fill="url(#${id}-rs)"/>` +
+    `<path d="M22.5 -30 V18 M41.5 -30 V18" stroke="#2A2220" stroke-width="1.6"/>` +
+    `</g>` +
+    `<defs>` +
+    `<pattern id="${id}-r" width="19" height="6" patternUnits="userSpaceOnUse"><rect width="19" height="3" fill="#D3CCC4"/><rect y="3" width="19" height="2" fill="#8F877F"/><rect y="5" width="19" height="1" fill="#6E665F"/></pattern>` +
+    `<linearGradient id="${id}-rs" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#fff" stop-opacity=".6"/><stop offset=".4" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity=".32"/></linearGradient>` +
+    `</defs>`
   )
 }
 

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -45,7 +45,9 @@ export const SKINS = [
     title: 'Block Mine',
     pieces: mine.pieces,
     hidden: mine.hidden,
-    motion: { seconds: .62, lift: 0, spin: 0, stagger: .14, land: 'breakpop' },
+    // a mined move is long on purpose: pickaxe swings, the carrier's trip,
+    // the set-down. stagger is small so a run is one trip, not a queue.
+    motion: { seconds: 1.3, lift: 0, spin: 0, stagger: .08, land: 'mine' },
     sound: 'stone',
     preview: stack(mine.pieces[1].svg, mine.pieces[0].svg),
   },

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -1,6 +1,7 @@
 <script>
   import { flightKeyframes, flightOptions } from './flight.js'
   import { fx } from './fx.js'
+  import { mine as mineActors } from './actors.js'
 
   let { store } = $props()
 
@@ -89,6 +90,7 @@
     if (matchMedia('(prefers-reduced-motion: reduce)').matches) { before = new Map(); return }
     const motion = store.skin.motion ?? { seconds: .22, lift: 1, spin: 0, stagger: 0, land: 'drop' }
     let index = 0
+    const trips = [] // what an actor-driven move needs to know about each item
     for (const [uid, from] of before) {
       const node = boardEl.querySelector(`[data-uid="${uid}"]`)
       if (!node) continue
@@ -106,7 +108,7 @@
         spin: motion.spin ?? 0,
       })
       for (const a of node.getAnimations()) a.cancel()
-      node.style.transformOrigin = ['screw', 'roll', 'breakpop'].includes(verb) ? '50% 50%' : '50% 80%'
+      node.style.transformOrigin = ['screw', 'roll', 'breakpop', 'mine'].includes(verb) ? '50% 50%' : '50% 80%'
       node.dataset.flightSeq = flightSeq
       // css-side companions (a nut's turning band) sync to the same clock
       node.style.setProperty('--flight-secs', `${motion.seconds}s`)
@@ -117,10 +119,10 @@
       const anim = node.animate(keyframes, options)
       // a broken block bursts where it BROKE, at the source, when the shudder
       // ends (the flight's own timing), not where it respawns
-      if (burst && verb === 'breakpop') {
+      if (burst && (verb === 'breakpop' || verb === 'mine')) {
         setTimeout(() => {
           if (node.dataset.flightSeq === flightSeq) fx.land(from.rect, 'breakpop', [pieceColor(uid)])
-        }, options.delay + options.duration * 0.42)
+        }, options.delay + options.duration * (verb === 'mine' ? 0.28 : 0.42))
       }
       anim.finished.then(() => {
         if (node.dataset.flightSeq !== flightSeq) return
@@ -129,7 +131,15 @@
       }).catch(() => {
         if (node.dataset.flightSeq === flightSeq) node.classList.remove('flying')
       })
+      trips.push({ from: from.rect, to, svg: node.innerHTML, color: pieceColor(uid) })
       index += 1
+    }
+    // the mine move is PERFORMED: a pickaxe mines the source, a carrier brings
+    // the run over and sets it down. actors ride the pieces' seconds/stagger.
+    if (trips.length && motion.land === 'mine') {
+      mineActors(boardEl, trips, motion, {
+        warp: rect => fx.land(rect, 'warp', ['#D46BFF', '#7A2BC9']),
+      })
     }
     before = new Map()
   })

--- a/src/lib/ui/actors.js
+++ b/src/lib/ui/actors.js
@@ -1,0 +1,128 @@
+// actors: characters that perform a move on top of the board, timed to the
+// same clock as the pieces' own flight. the mine conversion's move is a
+// pickaxe that mines the source block, then a tall dark visitor who carries
+// the block over and sets it down. everything is drawn svg, nothing loaded.
+//
+// an actor layer is one absolutely positioned div inside #board; it removes
+// itself when the move's last animation settles. reduced-motion never gets
+// here (the Board skips the animated path entirely).
+
+const INK = '#0B0B14'
+
+function el(tag, cls, html) {
+  const node = document.createElement(tag)
+  if (cls) node.className = cls
+  if (html != null) node.innerHTML = html
+  return node
+}
+
+// a stone pickaxe: wooden haft, iron head. drawn with the haft end at the
+// origin so a rotation swings it like a real one.
+const PICKAXE =
+  `<svg viewBox="-4 -60 68 68" aria-hidden="true">` +
+  `<path d="M0 0 L38 -38" stroke="#7A5233" stroke-width="7" stroke-linecap="round"/>` +
+  `<path d="M0 0 L38 -38" stroke="#5A3A22" stroke-width="3" stroke-linecap="round" opacity=".6"/>` +
+  `<path d="M22 -54 Q40 -60 56 -40 Q46 -38 40 -40 Q44 -30 38 -20 Q30 -34 22 -54 Z" fill="#B9B9B9" stroke="${INK}" stroke-width="2.4" stroke-linejoin="round"/>` +
+  `<path d="M26 -50 Q38 -52 48 -42" stroke="#E6E6E6" stroke-width="2" fill="none" stroke-linecap="round"/>` +
+  `</svg>`
+
+// the visitor: tall, thin, dark, with glowing violet eyes and long arms that
+// hold the block out in front. body 64 wide by 150 tall in svg units; the
+// block slot is a 40x40 square at (12, 58). an aesthetic tribute, ours.
+function visitor(blockSvg) {
+  return (
+    `<svg viewBox="0 0 64 150" aria-hidden="true">` +
+    `<rect x="24" y="4" width="16" height="16" rx="2" fill="${INK}"/>` +
+    `<rect x="25" y="10" width="5" height="3" fill="#D46BFF"/><rect x="34" y="10" width="5" height="3" fill="#D46BFF"/>` +
+    `<rect x="25" y="10" width="5" height="3" fill="#fff" opacity=".35"/><rect x="34" y="10" width="5" height="3" fill="#fff" opacity=".35"/>` +
+    `<rect x="26" y="20" width="12" height="62" fill="${INK}"/>` +
+    `<rect x="26" y="82" width="5" height="64" fill="${INK}"/><rect x="33" y="82" width="5" height="64" fill="${INK}"/>` +
+    // arms reach forward and down to the block
+    `<path d="M27 24 L10 62 L14 96" stroke="${INK}" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>` +
+    `<path d="M37 24 L54 62 L50 96" stroke="${INK}" stroke-width="5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>` +
+    `<g class="held" transform="translate(12 58) scale(.625)">${blockSvg}</g>` +
+    `</svg>`
+  )
+}
+
+// trips: [{ from: DOMRect, to: DOMRect, svg, color }] bottom-to-top of the
+// moved run. motion: the skin's motion. returns a promise for the layer's end.
+export function mine(boardEl, trips, motion, hooks = {}) {
+  const board = boardEl.getBoundingClientRect()
+  const S = motion.seconds * 1000
+  const d = (motion.stagger ?? 0) * 1000
+  const n = trips.length
+  const side = trips[0].from.width
+  const layer = el('div', 'actor-layer')
+  boardEl.appendChild(layer)
+  const rel = r => ({ x: r.left - board.left, y: r.top - board.top })
+
+  const settled = []
+
+  // the pickaxe swings at each block from the top of the run down. a swing
+  // is three quick chops across the block's own shudder window (0 .. .28S)
+  for (let k = n - 1; k >= 0; k--) {
+    const at = rel(trips[k].from)
+    const pick = el('div', 'actor pickaxe', PICKAXE)
+    // the haft's end sits just off the block's right shoulder so the head
+    // swings down INTO the block rather than through it
+    pick.style.cssText = `left:${at.x + side * 0.8}px;top:${at.y - side * 0.25}px;width:${side * 1.1}px;height:${side * 1.1}px`
+    layer.appendChild(pick)
+    const delay = (n - 1 - k) * d
+    const a = pick.animate([
+      { transform: 'rotate(-60deg)', opacity: 0, offset: 0 },
+      { transform: 'rotate(-60deg)', opacity: 1, offset: 0.08 },
+      { transform: 'rotate(28deg)', offset: 0.32 },
+      { transform: 'rotate(-55deg)', offset: 0.5 },
+      { transform: 'rotate(28deg)', offset: 0.7 },
+      { transform: 'rotate(-55deg)', offset: 0.86 },
+      { transform: 'rotate(30deg)', opacity: 1, offset: 0.96 },
+      { transform: 'rotate(30deg)', opacity: 0, offset: 1 },
+    ], { duration: S * 0.3, delay, easing: 'linear', fill: 'both' })
+    settled.push(a.finished)
+  }
+
+  // the visitor appears where the run was, carrying the whole run, floats
+  // across, and fades once the last block is set down
+  const top = trips[n - 1]
+  const dest = trips[0]
+  const src = rel(top.from)
+  const dst = rel(dest.to)
+  const stackSvg = trips.map((t, i) => `<g transform="translate(0 ${-(i) * 64})">${t.svg}</g>`).join('')
+  const who = el('div', 'actor visitor', visitor(stackSvg))
+  const h = side * 2.35
+  who.style.cssText = `left:${src.x}px;top:${src.y + side - h}px;width:${side}px;height:${h}px`
+  layer.appendChild(who)
+  const appear = S * 0.3 + (n - 1) * d
+  const arrive = S * 0.8
+  const gone = S * 0.86 + n * d
+  const dx = dst.x - src.x
+  const dy = (dst.y + side) - (src.y + side)
+  const total = gone + S * 0.12
+  const w = who.animate([
+    { transform: 'translate(0px, 0px)', opacity: 0, offset: 0 },
+    { transform: 'translate(0px, 0px)', opacity: 0, offset: appear / total },
+    { transform: 'translate(0px, -6px)', opacity: 1, offset: (appear + S * 0.08) / total },
+    { transform: `translate(${dx * 0.5}px, ${dy * 0.5 - side * 0.6}px)`, opacity: 1, easing: 'ease-in-out', offset: (appear + (arrive - appear) * 0.5) / total },
+    { transform: `translate(${dx}px, ${dy}px)`, opacity: 1, offset: arrive / total },
+    { transform: `translate(${dx}px, ${dy}px)`, opacity: 1, offset: gone / total },
+    { transform: `translate(${dx}px, ${dy - 10}px)`, opacity: 0, offset: 1 },
+  ], { duration: total, easing: 'linear', fill: 'both' })
+  settled.push(w.finished)
+  // the held stack lets go as the blocks pop into place
+  const held = who.querySelector('.held')
+  if (held) {
+    settled.push(held.animate([
+      { opacity: 1, offset: 0 },
+      { opacity: 1, offset: arrive / total },
+      { opacity: 0, offset: (arrive + S * 0.06) / total },
+      { opacity: 0, offset: 1 },
+    ], { duration: total, easing: 'linear', fill: 'both' }).finished)
+  }
+  if (hooks.warp) {
+    setTimeout(() => hooks.warp(top.from), appear)
+    setTimeout(() => hooks.warp(dest.to), gone)
+  }
+
+  return Promise.allSettled(settled).then(() => layer.remove())
+}

--- a/src/lib/ui/flight.js
+++ b/src/lib/ui/flight.js
@@ -77,6 +77,21 @@ export function flightKeyframes(verb, { dx, dy, peakRel, rimRel, spin }) {
         { transform: 'translate(0px, 0px) rotate(0deg) scale(1.14)', opacity: 1, easing: 'ease-out', offset: 0.76 },
         { transform: 'translate(0px, 0px) rotate(0deg) scale(1)', opacity: 1, offset: 1 },
       ]
+    case 'mine':
+      // the block is MINED: three shudders under the pickaxe (actors.js swings
+      // on the same beats), gone at .28, carried over unseen, set down at .82.
+      // the invisible position swap is the carrier's job, not the block's.
+      return [
+        { transform: `${start} rotate(0deg) scale(1)`, opacity: 1, offset: 0 },
+        { transform: `translate(${dx - 3}px, ${dy + 1}px) rotate(-3deg) scale(1.02)`, opacity: 1, offset: 0.08 },
+        { transform: `translate(${dx + 3}px, ${dy - 1}px) rotate(3deg) scale(1)`, opacity: 1, offset: 0.16 },
+        { transform: `translate(${dx - 2}px, ${dy + 1}px) rotate(-3deg) scale(.96)`, opacity: 1, offset: 0.23 },
+        { transform: `${start} rotate(0deg) scale(.1)`, opacity: 0, offset: 0.28 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(.1)', opacity: 0, offset: 0.29 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(.1)', opacity: 0, offset: 0.82 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(1.12)', opacity: 1, easing: 'ease-out', offset: 0.92 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(1)', opacity: 1, offset: 1 },
+      ]
     case 'flip':
       return [
         { transform: `${start} rotate(0deg)`, easing: LAUNCH, offset: 0 },
@@ -169,6 +184,7 @@ export function landingTimes(motion, count, verb = motion.land) {
   const beat = {
     screw: 0.52,
     breakpop: 0.76,
+    mine: 0.82,
     flip: 0.82,
     roll: 0.88,
     fly: 1,

--- a/src/lib/ui/fx.js
+++ b/src/lib/ui/fx.js
@@ -30,6 +30,8 @@ function fit() {
 const RECIPES = {
   screw: { n: 7, colors: ['#FFE9A8', '#FFD54A', '#FFFFFF'], shape: 'spark', speed: 130, up: .4, grav: 260, life: .28 },
   breakpop: { n: 14, colors: ['#B9A38C', '#75604A', '#D8C7A9'], shape: 'chunk', speed: 125, up: .85, grav: 460, life: .38 },
+  mine: { n: 10, colors: ['#B9A38C', '#75604A', '#D8C7A9'], shape: 'chunk', speed: 90, up: .7, grav: 400, life: .3 },
+  warp: { n: 12, colors: ['#D46BFF', '#7A2BC9', '#F2C6FF'], shape: 'dot', speed: 60, up: 1.2, grav: -90, life: .5 },
   flip: { n: 9, colors: ['#3EF0D0', '#FF4FD8', '#FFFFFF'], shape: 'spark', speed: 165, up: .35, grav: 80, life: .24 },
   roll: { n: 7, colors: ['#FFE63F', '#FF8A00', '#FFFFFF'], shape: 'spark', speed: 120, up: .3, grav: 150, life: .24 },
   fly: { n: 8, colors: ['#3F7BFF', '#3EF0D0', '#FFFFFF'], shape: 'spark', speed: 180, up: .55, grav: 40, life: .3 },

--- a/src/lib/ui/sounds.js
+++ b/src/lib/ui/sounds.js
@@ -93,11 +93,20 @@ const MATERIALS = {
     tone({ freq: 300 - i * 18, glide: 210, type: 'triangle', at, len: 0.09, vol: 0.13 })
     noise({ at, len: 0.05, vol: 0.07, freq: 900, q: 0.8 })
   },
-  stone(at) {
-    // the break: two crunches while the source block shudders, then the pop
-    // where it respawns. spacing matches the breakpop keyframes by ear.
-    noise({ at: Math.max(0, at - 0.2), len: 0.06, vol: 0.09, freq: 900, q: 0.7 })
-    noise({ at: Math.max(0, at - 0.1), len: 0.07, vol: 0.11, freq: 600, q: 0.7 })
+  stone(at, i) {
+    // a mined move, timed to the 'mine' keyframes at 1.3s: three pickaxe
+    // clinks while the block shudders (.05 .15 .25 s), the crunch as it
+    // breaks (.36), the carrier's whoosh in and out, then the set-down thud.
+    const t0 = Math.max(0, at - 1.3 * 0.82)
+    for (let c = 0; c < 3; c++) {
+      noise({ at: t0 + 0.05 + c * 0.1, len: 0.035, vol: 0.1, freq: 3400 + c * 300, q: 5 })
+      tone({ freq: 1900 + c * 120, glide: 1500, type: 'triangle', at: t0 + 0.05 + c * 0.1, len: 0.04, vol: 0.04 })
+    }
+    noise({ at: t0 + 0.36, len: 0.09, vol: 0.12, freq: 600, q: 0.7 })
+    if (i === 0) {
+      tone({ freq: 260, glide: 900, type: 'sine', at: t0 + 0.42, len: 0.16, vol: 0.05 })
+      tone({ freq: 900, glide: 260, type: 'sine', at: at + 0.16, len: 0.16, vol: 0.05 })
+    }
     tone({ freq: 150, glide: 90, type: 'sine', at, len: 0.12, vol: 0.16 })
     noise({ at, len: 0.09, vol: 0.1, freq: 420, q: 0.6 })
   },

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -10,7 +10,7 @@ let failures = 0
 const fail = msg => { failures += 1; console.error('FAIL ' + msg) }
 
 const GEO = { dx: -120, dy: 80, peakRel: -140, rimRel: -60 }
-const VERBS = new Set(['drop', 'screw', 'breakpop', 'flip', 'roll', 'fly', 'hover', 'zig', 'squish', 'tumble'])
+const VERBS = new Set(['drop', 'screw', 'breakpop', 'mine', 'flip', 'roll', 'fly', 'hover', 'zig', 'squish', 'tumble'])
 const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop', 'cute', 'dice'])
 const CONVERSIONS = ['bolts', 'mine', 'dash', 'kawaii', 'dice', 'tubes']
 const CSS = readFileSync(new URL('../src/app.css', import.meta.url), 'utf8')
@@ -43,7 +43,7 @@ function verifyFlight(verb, motion, id) {
     fail(`${id}: lands tilted (${keyframes.at(-1).transform})`)
   }
 
-  if (verb === 'breakpop') {
+  if (verb === 'breakpop' || verb === 'mine') {
     const hiddenAtDestination = keyframes.some(frame => {
       const point = translateOf(frame.transform)
       return frame.opacity === 0 && point?.x === 0 && point?.y === 0


### PR DESCRIPTION
**bolts**: the post is a straight flat-topped threaded rod (a bolt, not a screw), sized to the nut's bore. each nut carries a hidden rod segment rising out of its bore; css shows it on the top nut of a stack and on a nut in flight, so the rod visibly passes THROUGH the nut instead of the nut resting on top. combined with the side-band turn from the last increment, a nut now screws down the rod.

**mine**: the move is performed. a pickaxe appears at the top block of the run and chops three times on the block's own shudder beats; the block breaks with a burst where it stood; a tall dark carrier fades in holding the whole run, floats over to the destination column, sets the blocks down as they pop into place, and fades out with a violet warp at both ends. new `mine` verb (1.3s), `stone` sound rewritten to the same beats (three clinks, crunch, whoosh in/out, thud). actors live in src/lib/ui/actors.js on an absolutely positioned layer inside #board that removes itself when the last animation settles.

gates: verify-flight (6 conversions, 11 verbs, 60 pieces, the mined verb proves the hidden swap), copy lint, svelte-check 0/0, build, real-browser frame strips of both moves reviewed, zero actor layers left behind, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG