### PR TITLE
actors: a performance belongs to one move sequence (refs #29)

### DIFF
--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -75,9 +75,18 @@
       })
     }
   })
+  // the running actor performance, if any. it belongs to ONE move sequence:
+  // any later sequence (a second move, undo, reset, a skin change) or an
+  // unmount tears it down before it can keep performing over a board that no
+  // longer has that move.
+  let actorRun = null
+  $effect(() => () => { actorRun?.cancel(); actorRun = null }) // unmount only
   $effect(() => {
     const flightSeq = String(store.moveSeq)
     if (!boardEl) return
+    // a re-run for the SAME sequence (a resize re-measuring `side`) keeps the
+    // performance; only a new sequence ends it
+    if (actorRun && actorRun.seq !== flightSeq) { actorRun.cancel(); actorRun = null }
     // A rapid second move or undo owns the node now. Cancel the old compositor
     // work before starting (or declining) this sequence; its settled promise
     // is sequence-guarded below so it cannot tear down the new flight's cue.
@@ -137,9 +146,11 @@
     // the mine move is PERFORMED: a pickaxe mines the source, a carrier brings
     // the run over and sets it down. actors ride the pieces' seconds/stagger.
     if (trips.length && motion.land === 'mine') {
-      mineActors(boardEl, trips, motion, {
+      actorRun = mineActors(boardEl, trips, motion, {
         warp: rect => fx.land(rect, 'warp', ['#D46BFF', '#7A2BC9']),
       })
+      actorRun.seq = flightSeq
+      actorRun.done.then(() => { if (actorRun?.seq === flightSeq) actorRun = null })
     }
     before = new Map()
   })

--- a/src/lib/ui/actors.js
+++ b/src/lib/ui/actors.js
@@ -46,7 +46,11 @@ function visitor(blockSvg) {
 }
 
 // trips: [{ from: DOMRect, to: DOMRect, svg, color }] bottom-to-top of the
-// moved run. motion: the skin's motion. returns a promise for the layer's end.
+// moved run. motion: the skin's motion. returns a handle: `done` settles when
+// the layer has removed itself, `cancel()` tears the performance down early
+// (undo, reset, a skin change, unmount): every animation cancelled, every
+// pending warp timer cleared, the layer gone, so nothing keeps performing
+// over a board that no longer has that move.
 export function mine(boardEl, trips, motion, hooks = {}) {
   const board = boardEl.getBoundingClientRect()
   const S = motion.seconds * 1000
@@ -58,6 +62,16 @@ export function mine(boardEl, trips, motion, hooks = {}) {
   const rel = r => ({ x: r.left - board.left, y: r.top - board.top })
 
   const settled = []
+  const animations = []
+  const timers = []
+  let live = true
+  const cancel = () => {
+    if (!live) return
+    live = false
+    for (const a of animations) a.cancel()
+    for (const t of timers) clearTimeout(t)
+    layer.remove()
+  }
 
   // the pickaxe swings at each block from the top of the run down. a swing
   // is three quick chops across the block's own shudder window (0 .. .28S)
@@ -79,6 +93,7 @@ export function mine(boardEl, trips, motion, hooks = {}) {
       { transform: 'rotate(30deg)', opacity: 1, offset: 0.96 },
       { transform: 'rotate(30deg)', opacity: 0, offset: 1 },
     ], { duration: S * 0.3, delay, easing: 'linear', fill: 'both' })
+    animations.push(a)
     settled.push(a.finished)
   }
 
@@ -108,21 +123,25 @@ export function mine(boardEl, trips, motion, hooks = {}) {
     { transform: `translate(${dx}px, ${dy}px)`, opacity: 1, offset: gone / total },
     { transform: `translate(${dx}px, ${dy - 10}px)`, opacity: 0, offset: 1 },
   ], { duration: total, easing: 'linear', fill: 'both' })
+  animations.push(w)
   settled.push(w.finished)
   // the held stack lets go as the blocks pop into place
   const held = who.querySelector('.held')
   if (held) {
-    settled.push(held.animate([
+    const h = held.animate([
       { opacity: 1, offset: 0 },
       { opacity: 1, offset: arrive / total },
       { opacity: 0, offset: (arrive + S * 0.06) / total },
       { opacity: 0, offset: 1 },
-    ], { duration: total, easing: 'linear', fill: 'both' }).finished)
+    ], { duration: total, easing: 'linear', fill: 'both' })
+    animations.push(h)
+    settled.push(h.finished)
   }
   if (hooks.warp) {
-    setTimeout(() => hooks.warp(top.from), appear)
-    setTimeout(() => hooks.warp(dest.to), gone)
+    timers.push(setTimeout(() => { if (live) hooks.warp(top.from) }, appear))
+    timers.push(setTimeout(() => { if (live) hooks.warp(dest.to) }, gone))
   }
 
-  return Promise.allSettled(settled).then(() => layer.remove())
+  const done = Promise.allSettled(settled).then(() => { if (live) { live = false; layer.remove() } })
+  return { done, cancel }
 }


### PR DESCRIPTION
post-merge review of #36 found the actor run never cancelled: a mined move followed by undo, reset, or a skin change left the pickaxe and carrier performing over a board that no longer had that move.

fix: `actors.mine` returns a handle (`done`, `cancel`); cancel tears down every WAAPI animation, clears both warp timers, and removes the layer. Board keeps the running handle tagged with its move sequence and cancels it on any NEW sequence (a same-sequence re-run, such as a resize re-measuring `side`, keeps the performance) and on unmount.

proof: a browser oracle (move then immediate undo; move then immediate skin change; plus an uninterrupted control) FAILS on the deployed v0.1.14 (skin change leaves 1 layer, 2 actors, 2 running animations) and passes on this tree (0/0/0 in every interrupted case, control still performs). the oracle lives outside the repo gate because sortit carries no browser test dependency; the verify gate stays node-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG