### PR TITLE
bolts: the rod through every nut; a nut flies bare then threads down (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -291,10 +291,11 @@ h1 {
 [data-skin="bolts"] .tube { border-bottom-color: transparent; }
 [data-skin="bolts"] .item { position: relative; z-index: 1; padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
 [data-skin="bolts"] .item svg { scale: 1.04; overflow: visible; }
-/* the rod rises out of the TOP nut's bore, and out of a nut in flight, so the
-   bolt passes through the nut. a buried nut has the nut above covering it. */
-[data-skin="bolts"] .item:last-child .nut-rod,
-[data-skin="bolts"] .item.flying .nut-rod { display: block; }
+/* every nut shows the rod rising out of its bore: on the top nut it climbs into
+   the open, on a buried nut the nut above covers all but the short run between
+   them, which is exactly what a threaded stack looks like. hidden on none, or
+   the bore of every lower nut reads empty and the rod seems to stop at each. */
+[data-skin="bolts"] .nut-rod { display: block; }
 /* a flying nut TURNS about the bolt: its side-face band slides one full turn
    (two periods of 52 svg units) across the flight, timed to the same seconds
    and stagger delay the Board gave the trip, so the band ends where it began */

--- a/src/app.css
+++ b/src/app.css
@@ -296,11 +296,13 @@ h1 {
    them, which is exactly what a threaded stack looks like. hidden on none, or
    the bore of every lower nut reads empty and the rod seems to stop at each. */
 [data-skin="bolts"] .nut-rod { display: block; }
-/* a flying nut TURNS about the bolt: its side-face band slides one full turn
-   (two periods of 52 svg units) across the flight, timed to the same seconds
-   and stagger delay the Board gave the trip, so the band ends where it began */
-[data-skin="bolts"] .item.flying .nut-band {
-  animation: nutspin var(--flight-secs, .5s) linear var(--flight-delay, 0s) 1;
+/* in the air a nut flies BARE: no rod through it, no turning. once it is over
+   the post and threading down (the Board flips .threading at the descent
+   beat) the rod appears through it and its side-face band slides one full
+   turn (two periods of 52 svg units) across the rest of the trip. */
+[data-skin="bolts"] .item.flying:not(.threading) .nut-rod { display: none; }
+[data-skin="bolts"] .item.threading .nut-band {
+  animation: nutspin calc(var(--flight-secs, .5s) * .48) linear 1;
 }
 @keyframes nutspin {
   from { transform: translateX(0); }

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -93,7 +93,7 @@
     for (const node of boardEl.querySelectorAll('.item.flying')) {
       if (node.dataset.flightSeq === flightSeq) continue
       for (const animation of node.getAnimations()) animation.cancel()
-      node.classList.remove('flying')
+      node.classList.remove('flying', 'threading')
     }
     if (!before.size) return
     if (matchMedia('(prefers-reduced-motion: reduce)').matches) { before = new Map(); return }
@@ -133,12 +133,19 @@
           if (node.dataset.flightSeq === flightSeq) fx.land(from.rect, 'breakpop', [pieceColor(uid)])
         }, options.delay + options.duration * (verb === 'mine' ? 0.28 : 0.42))
       }
+      // a screwing nut flies bare, then THREADS: the descent beat of the screw
+      // keyframes (offset .52) is where the rod appears through it and it turns
+      if (verb === 'screw') {
+        setTimeout(() => {
+          if (node.dataset.flightSeq === flightSeq && node.classList.contains('flying')) node.classList.add('threading')
+        }, options.delay + options.duration * 0.52)
+      }
       anim.finished.then(() => {
         if (node.dataset.flightSeq !== flightSeq) return
-        node.classList.remove('flying')
+        node.classList.remove('flying', 'threading')
         if (burst) fx.land(node.getBoundingClientRect(), verb, artColors())
       }).catch(() => {
-        if (node.dataset.flightSeq === flightSeq) node.classList.remove('flying')
+        if (node.dataset.flightSeq === flightSeq) node.classList.remove('flying', 'threading')
       })
       trips.push({ from: from.rect, to, svg: node.innerHTML, color: pieceColor(uid) })
       index += 1


### PR DESCRIPTION
two things from play on v0.1.15:

1. only the top nut showed the rod rising out of its bore, so every nut below read as sitting on top of the bolt. now every nut shows its rod segment; the nut above covers all but the short run between them, which is what a threaded stack looks like.
2. a nut in flight carried the rod with it. now it flies bare (no rod, no turning) and picks up the rod and the side-band turn only once it is over the post and threading down (the Board flips `.threading` at the screw keyframes' descent beat, .52).

frames reviewed at .23s (bare in the air), .42s (rod through, band mid-turn), seated. svelte-check 0/0, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG