### PR TITLE
shell: open into the game, one text bar, MORE as a sheet, update toast (refs #29)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -136,10 +136,9 @@ h1 {
    reads without relying on the removed #sound id selector */
 .sound-toggle.muted { text-decoration: line-through; opacity: .62; }
 
-/* the in-game bottom nav: the house bar shape (craftrush / quarry). icon over a
-   tiny label reads at a glance and takes LESS height than the old fat chip row,
-   which gives the board back its vertical space. MENU is always one thumb away. */
-/* pinned edge to edge at the very bottom, safe-area aware (kidgames#5 rule 2) */
+/* the bottom bar: the house bar shape (craftrush / quarry), on every screen,
+   pinned edge to edge, safe-area aware (kidgames#5 rule 2). words only: a
+   short label reads at a glance and nothing has to be decoded. */
 #game-nav {
   position: fixed;
   left: 0; right: 0; bottom: 0;
@@ -150,13 +149,10 @@ h1 {
   padding: .35rem .4rem calc(.35rem + env(safe-area-inset-bottom));
   background: rgb(61 50 48 / .92);
 }
-/* reserve the bar's height so the board never hides under it */
-#game { padding-bottom: calc(4.4rem + env(safe-area-inset-bottom)); }
+/* reserve the bar's height so no screen hides under it */
+#game, #levels { padding-bottom: calc(4.4rem + env(safe-area-inset-bottom)); }
 #game-nav button {
   flex: 1;
-  display: grid;
-  place-items: center;
-  gap: .05rem;
   min-height: 2.9rem;
   padding: .3rem 0;
   border: 0;
@@ -164,11 +160,41 @@ h1 {
   background: var(--card);
   color: var(--ink);
   font: inherit;
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: .05em;
   cursor: pointer;
 }
-#game-nav button span { font-size: 1.1rem; line-height: 1; }
-#game-nav button b { font-size: .62rem; font-weight: 800; letter-spacing: .02em; }
+#game-nav button[data-active] { background: var(--accent); color: var(--ink-on-accent); }
 #game-nav button:active { transform: translateY(.1rem); }
+
+/* the update toast: one tap, straight into the new build */
+.toast {
+  position: fixed;
+  top: calc(.6rem + env(safe-area-inset-top));
+  left: 50%;
+  z-index: 60;
+  translate: -50% 0;
+  min-height: 44px;
+  padding: .7rem 1.1rem;
+  border: .18rem solid var(--line);
+  border-radius: 1rem;
+  background: var(--accent);
+  box-shadow: 0 .3rem 0 var(--line);
+  color: var(--ink-on-accent);
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+  animation: toast-in .35s cubic-bezier(.3,1.4,.5,1);
+}
+@keyframes toast-in {
+  from { translate: -50% -140%; }
+  to { translate: -50% 0; }
+}
+
+/* the MORE sheet: the old front page's list, one tap away from any screen */
+.more-list { display: flex; flex-direction: column; gap: .5rem; margin-bottom: .6rem; }
+.check-updates.ready { background: var(--accent); }
 
 /* ------------------------------------------------------------------- board */
 

--- a/src/lib/ui/Modal.svelte
+++ b/src/lib/ui/Modal.svelte
@@ -6,17 +6,21 @@
   // gives the dialog an accessible name (a modal with none is a screen-reader dead end).
   let { label, onclose, children } = $props()
   let el
+  // an unmount closes the element too, but that close is not the USER's: when
+  // one dialog opens another (MORE opens ABOUT), the store already moved on,
+  // and reporting the teardown as a close would clear the dialog it just opened
+  let unmounting = false
 
   $effect(() => {
     if (!el) return
     if (!el.open) el.showModal()
-    return () => { if (el?.open) el.close() }
+    return () => { unmounting = true; if (el?.open) el.close() }
   })
 
   const close = () => el?.close()
   function onclick(e) { if (e.target === el) el.close() } // backdrop click
 </script>
 
-<dialog bind:this={el} aria-label={label} onclose={() => onclose?.()} {onclick}>
+<dialog bind:this={el} aria-label={label} onclose={() => { if (!unmounting) onclose?.() }} {onclick}>
   {@render children(close)}
 </dialog>

--- a/src/lib/ui/store.svelte.js
+++ b/src/lib/ui/store.svelte.js
@@ -17,6 +17,9 @@ export { LEVEL_COUNT, WORLD_SIZE, WORLD_COUNT }
 
 const HINT_BUDGET = { maxNodes: 60000 }
 const PROGRESS_KEY = 'sortit:progress'
+// the game in progress: saved on every change so the app opens straight back
+// into it (a won board is not a game in progress, it clears the slot)
+const GAME_KEY = 'sortit:game'
 
 function loadProgress() {
   try {
@@ -52,7 +55,7 @@ function PARS_AT(n) { return PARS[n - 1] ?? null }
 function saveProgress(p) { try { localStorage.setItem(PROGRESS_KEY, JSON.stringify(p)) } catch { /* fine */ } }
 
 export function createStore() {
-  let screen = $state('menu')       // 'menu' | 'levels' | 'game'
+  let screen = $state('game')       // 'game' | 'levels': the app opens IN the game
   let board = $state(null)          // levels.js board being played
   let playSeq = 0                   // bumped per play(), so a stale deferred par lands nowhere
   let theme = $state(null)
@@ -156,7 +159,46 @@ export function createStore() {
       : ''
     won = { stars, detail, score, perfect: board.par != null && moves <= board.par, canNext }
     sound.win()
-    confetti(theme.items.map(i => i.color))
+    confetti((skin.pieces ?? theme.items).map(i => i.color))
+    saveGame()
+  }
+
+  // the in-progress slot. tubes carry uids and hidden flags, history is the
+  // undo stack, elapsed keeps the clock honest across a relaunch.
+  function saveGame() {
+    try {
+      if (!board || over) { localStorage.removeItem(GAME_KEY); return }
+      localStorage.setItem(GAME_KEY, JSON.stringify({
+        kind: board.kind, n: board.n, seed: board.seed,
+        tubes: $state.snapshot(tubes), moves, history,
+        elapsed: clockStart == null ? 0 : Date.now() - clockStart,
+        seen: [...seen],
+      }))
+    } catch { /* a blocked store only costs the resume */ }
+  }
+  function restoreGame() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(GAME_KEY) ?? 'null')
+      if (!raw || !Array.isArray(raw.tubes)) return false
+      const b = raw.kind === 'level' && Number.isInteger(raw.n) && raw.n >= 1 && raw.n <= LEVEL_COUNT
+        ? levelBoard(raw.n)
+        : (raw.kind === 'seed' && Number.isInteger(raw.seed) && raw.seed > 0 ? seedBoard(raw.seed) : null)
+      if (!b) return false
+      const okItem = i => i && Number.isInteger(i.uid) && Number.isInteger(i.c) && i.c >= 0 && i.c < b.params.colors && typeof i.hid === 'boolean'
+      if (raw.tubes.length !== b.tubes.length || !raw.tubes.every(t => Array.isArray(t) && t.every(okItem))) return false
+      play(b)
+      tubes = raw.tubes.map(t => t.map(i => ({ ...i })))
+      uidNext = Math.max(0, ...raw.tubes.flat().map(i => i.uid)) + 1
+      moves = Number.isInteger(raw.moves) && raw.moves >= 0 ? raw.moves : 0
+      history = Array.isArray(raw.history) ? raw.history : []
+      seen = new Set(Array.isArray(raw.seen) ? raw.seen : [])
+      clockStart = Date.now() - (Number.isFinite(raw.elapsed) && raw.elapsed > 0 ? raw.elapsed : 0)
+      tick()
+      stuck = !anyPlayerMove()
+      return true
+    } catch {
+      return false
+    }
   }
 
   function tap(index) {
@@ -191,6 +233,7 @@ export function createStore() {
     if (doneNow && !isWin(numeric(), capacity)) sound.tube()
     if (isWin(numeric(), capacity)) { finishWin(); return }
     stuck = !anyPlayerMove()
+    saveGame()
   }
 
   function themeForBoard(b) {
@@ -225,7 +268,12 @@ export function createStore() {
     // par (and with it "best possible" + the 3-star goal on the win card).
     const token = ++playSeq
     setTimeout(() => { if (playSeq === token) board.par = parFor(b) }, 0)
+    saveGame()
   }
+
+  // the app opens in a game: the one in progress if there is one, else the
+  // player's current level. a ?level= or ?seed= link replaces it on mount.
+  if (typeof window !== 'undefined' && !restoreGame()) play(levelBoard(progress.current))
 
   return {
     // reactive reads
@@ -259,8 +307,8 @@ export function createStore() {
     tap,
     visibleRun,
     isTubeDone: t => isComplete(colorsOf(t), capacity) && !t.some(i => i.hid),
-    goMenu() { screen = 'menu' },
-    openLevels() { world = Math.floor((progress.current - 1) / WORLD_SIZE); screen = 'levels' },
+    goGame() { screen = 'game' },
+    openLevels() { world = Math.floor(((board?.kind === 'level' ? board.n : progress.current) - 1) / WORLD_SIZE); screen = 'levels' },
     setWorld(w) { world = Math.max(0, Math.min(WORLD_COUNT - 1, w)) },
     startLevel(n) { play(levelBoard(n)) },
     startDaily() { play(seedBoard(dailySeed())) },
@@ -279,6 +327,7 @@ export function createStore() {
       moves = last.moves
       won = null
       stuck = false
+      saveGame()
     },
     hint() {
       if (over) return true

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,6 +34,10 @@
 
     // two tabs sharing one store: adopt the better progress rather than clobber
     addEventListener('storage', e => { if (e.key === 'sortit:progress') store.mergeExternalProgress() })
+
+    // kit polls the deployed version on its own interval; coming back to the
+    // app is the moment a player would want to know, so ask right then too
+    document.addEventListener('visibilitychange', () => { if (!document.hidden) updated.check().catch(() => {}) })
   })
 
   function toggleSound() { muted = sound.toggle() }
@@ -50,11 +54,6 @@
     try { await navigator.clipboard.writeText(url.toString()); return 'copied' } catch { return 'failed' }
   }
 
-  let friendLabel = $state('PLAY WITH A FRIEND')
-  async function shareFriend() {
-    const r = await share(store.screen === 'game' ? store.board : { kind: 'seed', seed: dailySeed() })
-    if (r === 'copied') { friendLabel = 'LINK COPIED, SEND IT'; setTimeout(() => friendLabel = 'PLAY WITH A FRIEND', 2400) }
-  }
   let winShareLabel = $state('SEND THIS PUZZLE TO A FRIEND')
   async function shareWin() {
     const r = await share(store.board)
@@ -72,12 +71,11 @@
     if (iosInstall) store.openDialog('ios-install')
   }
 
-  // update check: compare the served shell against the booted one, so a stale
-  // installed client can pull the current deploy (kit worker is passive)
   // kit's own version check: `updated.current` is true when the DEPLOYED version
   // differs from the one THIS build booted with (the version is baked into the
   // running bundle, so there is no stale-baseline trap). updated.check() forces it.
   async function checkUpdates() {
+    if (updateState === 'stale') { location.reload(); return } // the button IS the reload once an update is ready
     updateState = 'checking'
     try {
       const stale = await updated.check()
@@ -93,41 +91,18 @@
 </script>
 
 <!-- house version stamp: fixed top-right on every screen (the fleet pattern, matches
-     quantamari's soft treatment). the .version-stamp css was already here; nothing wired it. -->
+     quantamari's soft treatment). -->
 <div class="version-stamp" aria-hidden="true">v{version}</div>
 
-{#if store.screen === 'menu'}
-  <main class="screen" id="menu">
-    <h1>Sort It</h1>
-    <p class="tagline">sort everything into tidy tubes</p>
-    <button class="big" onclick={() => store.startLevel(store.progress.current)}>PLAY</button>
-    <button class="big secondary" onclick={() => store.startDaily()}>TODAY'S PUZZLE</button>
-    <button class="big secondary" onclick={() => store.openLevels()}>PICK A LEVEL</button>
-    <button class="big secondary" onclick={shareFriend}>{friendLabel}</button>
-    <button class="big secondary" onclick={() => store.openDialog('howto')}>HOW TO PLAY</button>
-    <button class="big secondary" onclick={() => store.openDialog('looks')}>LOOKS</button>
-    <button class="big secondary sound-toggle" class:muted onclick={toggleSound} aria-pressed={!muted}>&#9834; SOUND{muted ? ' (off)' : ''}</button>
-    {#if installable}<button class="big secondary" onclick={doInstall}>ADD TO HOME SCREEN</button>{/if}
-    <button class="big secondary" onclick={() => store.openDialog('about')}>ABOUT</button>
-    <p class="ethos">no ads &middot; no timers &middot; nothing to buy &middot; no cookies</p>
-  </main>
-  <!-- the house bottom bar, present on EVERY screen. same styling and placement
-       throughout; the CONTENTS are genre-appropriate (kidgames#5): tabs while you are
-       choosing, in-play controls while you are solving. a launch screen with no bar at
-       all is what this closes. -->
-  <nav id="game-nav" aria-label="Main">
-    <button onclick={() => store.startLevel(store.progress.current)} aria-label="Play"><span aria-hidden="true">&#9654;</span><b>PLAY</b></button>
-    <button onclick={() => store.openLevels()} data-active={store.screen === 'levels' ? '' : undefined} aria-label="Pick a level"><span aria-hidden="true">&#9776;</span><b>LEVELS</b></button>
-    <button onclick={() => store.openDialog('looks')} aria-label="Looks"><span aria-hidden="true">&#10024;</span><b>LOOKS</b></button>
-    <button onclick={() => store.openDialog('about')} aria-label="More"><span aria-hidden="true">&#9881;</span><b>MORE</b></button>
-  </nav>
-
+<!-- a deploy happened while this shell was open: one tap reloads into it -->
+{#if updated.current}
+  <button class="toast" onclick={() => location.reload()}>update ready, tap to reload</button>
 {/if}
 
 {#if store.screen === 'levels'}
   <main class="screen" id="levels">
     <header class="bar">
-      <button class="chip" onclick={() => store.goMenu()} aria-label="back to menu">&larr;</button>
+      <button class="chip" onclick={() => store.goGame()} aria-label="back to the game">&larr;</button>
       <span class="chip flat">world {store.world + 1} &middot; {worldTheme.title}</span>
     </header>
     <div class="world-nav">
@@ -157,27 +132,20 @@
       {Object.keys(store.progress.done).length ? `you've sorted ${Object.keys(store.progress.done).length} of ${LEVEL_COUNT} levels` : 'sort a level to leave your mark!'}
     </p>
   </main>
-  <!-- the house bottom bar, present on EVERY screen. same styling and placement
-       throughout; the CONTENTS are genre-appropriate (kidgames#5): tabs while you are
-       choosing, in-play controls while you are solving. a launch screen with no bar at
-       all is what this closes. -->
+  <!-- the house bottom bar, present on EVERY screen (kidgames#5). text only:
+       plain words read faster than a generic icon and there is nothing to decode. -->
   <nav id="game-nav" aria-label="Main">
-    <button onclick={() => store.startLevel(store.progress.current)} aria-label="Play"><span aria-hidden="true">&#9654;</span><b>PLAY</b></button>
-    <button onclick={() => store.openLevels()} data-active={store.screen === 'levels' ? '' : undefined} aria-label="Pick a level"><span aria-hidden="true">&#9776;</span><b>LEVELS</b></button>
-    <button onclick={() => store.openDialog('looks')} aria-label="Looks"><span aria-hidden="true">&#10024;</span><b>LOOKS</b></button>
-    <button onclick={() => store.openDialog('about')} aria-label="More"><span aria-hidden="true">&#9881;</span><b>MORE</b></button>
+    <button onclick={() => store.goGame()}>PLAY</button>
+    <button data-active onclick={() => store.openLevels()}>LEVELS</button>
+    <button onclick={() => store.openDialog('looks')}>LOOKS</button>
+    <button onclick={() => store.openDialog('more')}>MORE</button>
   </nav>
-
 {/if}
 
 {#if store.screen === 'game'}
   <main class="screen" id="game">
     <header class="bar">
       <span class="chip flat" id="board-label">{store.boardLabel}</span>
-      <!-- looks are swappable mid-level: the store drops any in-flight cue on a
-           skin change, and the board, moves, and clock are untouched. it sits
-           before the readouts so it never crowds the version stamp top-right. -->
-      <button class="chip" onclick={() => store.openDialog('looks')} aria-label="Change the look"><span aria-hidden="true">&#10024;</span></button>
       <span class="chip flat mono" aria-label="time elapsed">{store.clock}</span>
       <span class="chip flat mono" aria-live="polite">{store.moves} {store.moves === 1 ? 'move' : 'moves'}</span>
     </header>
@@ -185,10 +153,11 @@
     <Board {store} />
 
     <nav id="game-nav" aria-label="Game controls">
-      <button onclick={() => store.goMenu()} aria-label="Back to menu"><span aria-hidden="true">&#9776;</span><b>MENU</b></button>
-      <button onclick={doHint}><span aria-hidden="true">&#10024;</span><b>HINT</b></button>
-      <button onclick={() => store.undo()}><span aria-hidden="true">&#8630;</span><b>UNDO</b></button>
-      <button onclick={() => store.replay()}><span aria-hidden="true">&#8635;</span><b>RESET</b></button>
+      <button onclick={() => store.openLevels()}>LEVELS</button>
+      <button onclick={doHint}>HINT</button>
+      <button onclick={() => store.undo()}>UNDO</button>
+      <button onclick={() => store.openDialog('looks')}>LOOKS</button>
+      <button onclick={() => store.openDialog('more')}>MORE</button>
     </nav>
 
     {#if store.stuck && !store.won}
@@ -216,6 +185,24 @@
 {/if}
 
 <!-- ============ dialogs (real modal dialogs, see Modal.svelte) ============ -->
+{#if store.dialog === 'more'}
+  <Modal label="More" onclose={() => store.closeDialog()}>
+    {#snippet children(close)}
+      <h2>More</h2>
+      <div class="more-list">
+        <button class="big secondary" onclick={() => { store.replay(); close() }}>START THIS ONE OVER</button>
+        <button class="big secondary" onclick={() => { store.startDaily(); close() }}>TODAY'S PUZZLE</button>
+        <button class="big secondary" onclick={() => store.openDialog('howto')}>HOW TO PLAY</button>
+        <button class="big secondary sound-toggle" class:muted onclick={toggleSound} aria-pressed={!muted}>SOUND {muted ? 'OFF' : 'ON'}</button>
+        {#if installable}<button class="big secondary" onclick={doInstall}>ADD TO HOME SCREEN</button>{/if}
+        <button class="big secondary" onclick={() => store.openDialog('about')}>ABOUT</button>
+      </div>
+      <p class="ethos">no ads &middot; no timers &middot; nothing to buy &middot; no cookies</p>
+      <button class="big" onclick={close}>BACK</button>
+    {/snippet}
+  </Modal>
+{/if}
+
 {#if store.dialog === 'howto'}
   <Modal label="How to play" onclose={() => store.closeDialog()}>
     {#snippet children(close)}
@@ -277,10 +264,10 @@
         <a href="https://royashbrook.com/agents" target="_blank" rel="noreferrer">ai</a>
         <span aria-hidden="true" class="mark-dot">&middot;</span>
         <a href="https://github.com/sponsors/royashbrook" target="_blank" rel="noreferrer" class="mark-sponsor">sponsor me</a></p>
-      <button class="big secondary check-updates" onclick={checkUpdates}>
+      <p class="small center">version {version}</p>
+      <button class="big secondary check-updates" class:ready={updateState === 'stale'} onclick={checkUpdates}>
         {#if updateState === 'checking'}checking...{:else if updateState === 'current'}up to date{:else if updateState === 'stale'}update ready, tap to reload{:else if updateState === 'offline'}offline{:else}check for updates{/if}
       </button>
-      {#if updateState === 'stale'}<button class="big" onclick={() => location.reload()}>RELOAD NOW</button>{/if}
       <button class="big" onclick={close}>BACK</button>
     {/snippet}
   </Modal>


### PR DESCRIPTION
from play on v0.1.15:

- **opens into the game.** no front page. the in-progress game (tubes, hidden flags, move count, undo stack, clock) is saved on every change and restored on launch; a won board clears the slot so the next launch starts the next level. `?level=` / `?seed=` links still take over.
- **one bottom bar, words only.** LEVELS · HINT · UNDO · LOOKS · MORE in the game; PLAY · LEVELS · LOOKS · MORE on the level picker. no emoji, no icon-plus-label, and the in-game looks chip that shared HINT's sparkle is gone (LOOKS is in the bar).
- **MORE is a sheet**, not a page: start this one over, today's puzzle, how to play, sound on/off, add to home screen, about. "play with a friend" is removed from the shell (the win card still offers to send a puzzle).
- **update toast.** a deploy while the shell is open raises a toast at the top; one tap reloads. kit's version poll is nudged on every return to the tab.
- **about's "update ready, tap to reload" now reloads.** the button re-ran the check instead; the separate RELOAD NOW is gone.
- **fix under the hood:** a modal unmounting because another dialog opened (MORE opening ABOUT) fired its onclose and cleared the dialog the store had just opened, so ABOUT mounted and died in the same tick. Modal no longer reports an unmount as a user close.

proof (browser, 14/14): opens in the game with no menu; bar text exact; zero emoji nodes; a move survives a reload with the same tubes and count, and undo works after the resume; MORE lists the old front page and START OVER resets and closes; LEVELS has its own bar and PLAY returns; a mocked new version.json raises the toast and tapping it reloads; ABOUT's check finds the update and its button reloads. regressions: actor lifecycle oracle, mid-level look swap, and all four conversions still fly. copy lint clean, svelte-check 0/0, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG