### PR TITLE
bolts: compact posts and faster mine performance

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -252,7 +252,7 @@ h1 {
 .item {
   display: block;
   width: var(--side, 44px);
-  height: var(--side, 44px);
+  height: var(--item-h, var(--side, 44px));
   padding: 2px;
   will-change: transform;
   transition: transform .18s ease;
@@ -278,18 +278,17 @@ h1 {
 /* the landing-effects canvas: above the board, below the win sheet */
 .fxlayer { position: fixed; inset: 0; z-index: 8; pointer-events: none; }
 
-/* nuts & bolts: a machined bolt up the middle, coloured hex nuts riding it.
-   the shaft's angled thread and the nut's own bevel (in its svg) are what
-   make the screw-down landing read as threading, not spinning. */
+/* nuts & bolts: one machined post per tube, with coloured hex nuts riding it.
+   the shaft's angled thread and the nut's bevel make the landing read as a
+   mechanical screw move without drawing a second rod through every piece. */
 [data-skin="bolts"] .tube {
   border-color: transparent;
   border-bottom: .3rem solid var(--line);
   border-radius: 0;
   background: transparent;
 }
-/* the bolt: a straight threaded rod, flat on top (a bolt, not a screw), as
-   wide as the nut's bore so the rod segment drawn inside the top nut lines
-   up with it. the thread pitch is 6/64 of a side, the same as the nut's. */
+/* the bolt: a straight threaded rod, flat on top (a bolt, not a screw), and
+   narrow enough to stay inside the nuts' central bore. */
 [data-skin="bolts"] .tube::before {
   content: '';
   position: absolute;
@@ -316,23 +315,18 @@ h1 {
 }
 [data-skin="bolts"] .tube { border-bottom-color: transparent; }
 [data-skin="bolts"] .item { position: relative; z-index: 1; padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
-[data-skin="bolts"] .item svg { scale: 1.04; overflow: visible; }
-/* every nut shows the rod rising out of its bore: on the top nut it climbs into
-   the open, on a buried nut the nut above covers all but the short run between
-   them, which is exactly what a threaded stack looks like. hidden on none, or
-   the bore of every lower nut reads empty and the rod seems to stop at each. */
-[data-skin="bolts"] .nut-rod { display: block; }
-/* in the air a nut flies BARE: no rod through it, no turning. once it is over
-   the post and threading down (the Board flips .threading at the descent
-   beat) the rod appears through it and its side-face band slides one full
-   turn (two periods of 52 svg units) across the rest of the trip. */
-[data-skin="bolts"] .item.flying:not(.threading) .nut-rod { display: none; }
-[data-skin="bolts"] .item.threading .nut-band {
-  animation: nutspin calc(var(--flight-secs, .5s) * .48) linear 1;
+[data-skin="bolts"] .item svg { overflow: visible; }
+/* the tube owns the only post. the nut owns only its turning side band: first
+   it backs off the source thread, holds while crossing, then winds onto the
+   destination. no per-piece rod means no doubled shafts or fake gaps. */
+[data-skin="bolts"] .item.flying .nut-band {
+  animation: nutspin var(--flight-secs, .48s) linear 1;
 }
 @keyframes nutspin {
   from { transform: translateX(0); }
-  to { transform: translateX(-104px); }
+  22% { transform: translateX(112px); }
+  58% { transform: translateX(112px); }
+  to { transform: translateX(0); }
 }
 [data-skin="bolts"] .tube.sel { box-shadow: none; }
 

--- a/src/lib/engine/skinart/bolts.js
+++ b/src/lib/engine/skinart/bolts.js
@@ -6,17 +6,18 @@
 // the side faces live in a wide band under a clip. app.css slides that band
 // sideways while a nut is flying, so a nut screwing down the post visibly
 // TURNS about the bolt instead of tumbling in the plane of the screen.
-// drawn for a viewBox of 0 0 64 64.
+// drawn for a viewBox of 0 0 64 40. the short viewBox is deliberate: a nut
+// is squat hardware, not a square game tile. Board uses the skin's pieceRatio
+// so these stack tightly on one continuous tube-owned post.
 //
 // every piece module in skinart/ exports the same shape:
 //   { pieces: [12 x { key, color, svg }], hidden: svg }
 
 // the flattened hexagon of the top face, and the body below it
-const TOP = 'M6 18 L20 8 L44 8 L58 18 L44 28 L20 28 Z'
-const BODY = 'M6 18 L6 50 L20 60 L44 60 L58 50 L58 18 L44 28 L20 28 Z'
+const TOP = 'M4 10 L16 1 L48 1 L60 10 L48 19 L16 19 Z'
+const BODY = 'M4 10 L4 29 L16 39 L48 39 L60 29 L60 10 L48 19 L16 19 Z'
 // one period of the band: a lit side face, the front face, a shaded side
-// face (14 + 24 + 14 = 52 units). a full turn of the nut is two periods.
-export const BAND_PERIOD = 52
+// face (14 + 28 + 14 = 56 units). a full turn of the nut is two periods.
 
 // the twelve marks, each centred at (0,0) in a 16-unit box
 const MARKS = {
@@ -54,10 +55,10 @@ function nut(key, face, lit, shade, mark) {
   const id = `nut-${key}`
   // one period of side faces; the mark rides the front face only
   const period = (x) =>
-    `<rect x="${x}" y="18" width="14" height="42" fill="${lit}"/>` +
-    `<rect x="${x + 14}" y="18" width="24" height="42" fill="${face}"/>` +
-    `<rect x="${x + 38}" y="18" width="14" height="42" fill="${shade}"/>` +
-    `<path d="${MARKS[mark]}" fill="#fff" opacity=".92" transform="translate(${x + 26} 42)"/>`
+    `<rect x="${x}" y="10" width="14" height="29" fill="${lit}"/>` +
+    `<rect x="${x + 14}" y="10" width="28" height="29" fill="${face}"/>` +
+    `<rect x="${x + 42}" y="10" width="14" height="29" fill="${shade}"/>` +
+    `<path d="${MARKS[mark]}" fill="#fff" opacity=".92" transform="translate(${x + 28} 28) scale(.82)"/>`
   return (
     `<defs>` +
     `<clipPath id="${id}-c"><path d="${BODY}"/></clipPath>` +
@@ -68,35 +69,23 @@ function nut(key, face, lit, shade, mark) {
     // the side faces: a band three periods wide, clipped to the body. the
     // band starts one period left so the front face sits centre at rest.
     `<g clip-path="url(#${id}-c)">` +
-    `<g class="nut-band">${period(-46)}${period(6)}${period(58)}</g>` +
+    `<g class="nut-band">${period(-52)}${period(4)}${period(60)}</g>` +
     // the bottom bevel and a soft vertical shading over the whole body
-    `<path d="M6 44 L6 50 L20 60 L44 60 L58 50 L58 44 L44 54 L20 54 Z" fill="#000" opacity=".22"/>` +
-    `<rect x="6" y="18" width="52" height="42" fill="url(#${id}-v)"/>` +
+    `<path d="M4 33 L4 29 L16 39 L48 39 L60 29 L60 33 L48 40 L16 40 Z" fill="#000" opacity=".22"/>` +
+    `<rect x="4" y="10" width="56" height="29" fill="url(#${id}-v)"/>` +
     `</g>` +
     `<defs><linearGradient id="${id}-v" x1="0" y1="0" x2="0" y2="1">` +
     `<stop offset="0" stop-color="#fff" stop-opacity=".18"/><stop offset=".5" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity=".18"/>` +
     `</linearGradient></defs>` +
     // the top face, lit from the upper left, and the threaded bore
     `<path d="${TOP}" fill="url(#${id}-t)"/>` +
-    `<ellipse cx="32" cy="18" rx="9.5" ry="4.6" fill="#2E2A27"/>` +
-    `<ellipse cx="32" cy="17.4" rx="7" ry="3.2" fill="none" stroke="#8C847C" stroke-width="1" stroke-dasharray="2 1.4" opacity=".7"/>` +
+    `<ellipse cx="32" cy="10" rx="10" ry="4.8" fill="#2E2A27"/>` +
+    `<ellipse cx="32" cy="9.6" rx="7" ry="3.1" fill="#A8A19A" stroke="#625B55" stroke-width="1" stroke-dasharray="2 1.4"/>` +
+    `<ellipse cx="30" cy="8.8" rx="3.8" ry="1.1" fill="#fff" opacity=".38"/>` +
     // the edges
     `<path d="${TOP}" fill="none" stroke="#2A2220" stroke-width="2" stroke-linejoin="round"/>` +
-    `<path d="M6 18 L6 50 L20 60 L44 60 L58 50 L58 18" fill="none" stroke="#2A2220" stroke-width="2.2" stroke-linejoin="round"/>` +
-    `<path d="M20 28 L20 60 M44 28 L44 60" stroke="#2A2220" stroke-width="1.2" opacity=".55"/>` +
-    // the rod rising out of the bore. hidden on nuts buried in a stack (the
-    // nut above covers it) and shown by app.css on the top nut and on a nut in
-    // flight, so the bolt visibly passes THROUGH the nut instead of stopping
-    // at it. same width as the bore, same thread pitch as the css post.
-    `<g class="nut-rod" display="none">` +
-    `<rect x="22.5" y="-30" width="19" height="48" fill="url(#${id}-r)"/>` +
-    `<rect x="22.5" y="-30" width="19" height="48" fill="url(#${id}-rs)"/>` +
-    `<path d="M22.5 -30 V18 M41.5 -30 V18" stroke="#2A2220" stroke-width="1.6"/>` +
-    `</g>` +
-    `<defs>` +
-    `<pattern id="${id}-r" width="19" height="6" patternUnits="userSpaceOnUse"><rect width="19" height="3" fill="#D3CCC4"/><rect y="3" width="19" height="2" fill="#8F877F"/><rect y="5" width="19" height="1" fill="#6E665F"/></pattern>` +
-    `<linearGradient id="${id}-rs" x1="0" y1="0" x2="1" y2="0"><stop offset="0" stop-color="#fff" stop-opacity=".6"/><stop offset=".4" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity=".32"/></linearGradient>` +
-    `</defs>`
+    `<path d="M4 10 L4 29 L16 39 L48 39 L60 29 L60 10" fill="none" stroke="#2A2220" stroke-width="2.2" stroke-linejoin="round"/>` +
+    `<path d="M16 19 L16 39 M48 19 L48 39" stroke="#2A2220" stroke-width="1.2" opacity=".55"/>`
   )
 }
 
@@ -104,6 +93,6 @@ export default {
   pieces: NUTS.map(([key, face, lit, shade, mark]) => ({ key: `${key} nut`, color: face, svg: nut(key, face, lit, shade, mark) })),
   // a mystery nut: dull unfinished steel, a question mark on the front face
   hidden: nut('hid', '#A39B93', '#D9D3CC', '#5E5751', 'dot')
-    .replace(/<path d="[^"]*" fill="#fff" opacity="\.92" transform="translate\(32 42\)"\/>/,
-      `<path d="M-4 -5 Q-4 -10 0 -10 Q4 -10 4 -6 Q4 -3 1 -2 L1 0" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" transform="translate(32 42)"/><circle cx="33" cy="46" r="1.6" fill="#fff"/>`),
+    .replace(/<path d="[^"]*" fill="#fff" opacity="\.92" transform="translate\(32 28\) scale\(\.82\)"\/>/,
+      `<path d="M-4 -5 Q-4 -10 0 -10 Q4 -10 4 -6 Q4 -3 1 -2 L1 0" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" transform="translate(32 29) scale(.82)"/><circle cx="32.8" cy="32.5" r="1.4" fill="#fff"/>`),
 }

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -32,9 +32,12 @@ export const SKINS = [
     title: 'Nuts & Bolts',
     pieces: bolts.pieces,
     hidden: bolts.hidden,
+    pieceRatio: .625,
+    pieceViewBox: '0 0 64 40',
+    tubeLip: 22,
     // spin 0: the nut turns about the bolt via its own side band (app.css
     // nutspin), a planar rotate would read as tumbling in three-quarter view
-    motion: { seconds: .6, lift: 1.25, spin: 0, stagger: .09, land: 'screw' },
+    motion: { seconds: .48, lift: .75, spin: 0, stagger: .06, land: 'screw' },
     sound: 'metal',
     preview:
       `<rect x="29" y="2" width="6" height="60" fill="#B9AFA6" stroke="#2A2220" stroke-width="2"/>` +
@@ -45,9 +48,9 @@ export const SKINS = [
     title: 'Block Mine',
     pieces: mine.pieces,
     hidden: mine.hidden,
-    // a mined move is long on purpose: pickaxe swings, the carrier's trip,
-    // the set-down. stagger is small so a run is one trip, not a queue.
-    motion: { seconds: 1.3, lift: 0, spin: 0, stagger: .08, land: 'mine' },
+    // one clear strike, one carrier trip, one set-down. quick enough that the
+    // performance explains the move without making the player wait for it.
+    motion: { seconds: .9, lift: 0, spin: 0, stagger: .06, land: 'mine' },
     sound: 'stone',
     preview: stack(mine.pieces[1].svg, mine.pieces[0].svg),
   },

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -21,6 +21,8 @@
     const availHTotal = boardEl.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom)
     const count = store.tubes.length
     const capacity = store.capacity
+    const pieceRatio = store.skin.pieceRatio ?? 1
+    const tubeLip = store.skin.tubeLip ?? LIP
     if (!count) return
     // the tube button is the tap target and never goes below 44px (its min-width
     // in css). so a row layout is only feasible if that many 44px tubes fit the
@@ -32,7 +34,7 @@
       const widest = Math.ceil(count / rc)
       if (widest * TUBE_MIN + (widest - 1) * GAP > availW) continue // 44px tubes don't fit this row count
       const availH = availHTotal - (rc - 1) * GAP
-      const bySide = (availH / rc - LIP - PAD) / capacity
+      const bySide = (availH / rc - tubeLip - PAD) / (capacity * pieceRatio)
       const byWidth = (availW - (widest - 1) * GAP) / widest - PAD * 2
       const s = Math.min(64, bySide, byWidth)
       if (!best || s > best.s) best = { rc, s }
@@ -40,7 +42,7 @@
     if (!best) best = { rc: Math.min(4, count), s: 20 } // pathological fallback
     rowCount = best.rc
     side = Math.max(20, Math.min(64, best.s))
-    tubeH = side * capacity + LIP + PAD
+    tubeH = side * capacity * pieceRatio + tubeLip + PAD
     rowCount = best.rc
   }
 
@@ -93,7 +95,7 @@
     for (const node of boardEl.querySelectorAll('.item.flying')) {
       if (node.dataset.flightSeq === flightSeq) continue
       for (const animation of node.getAnimations()) animation.cancel()
-      node.classList.remove('flying', 'threading')
+      node.classList.remove('flying')
     }
     if (!before.size) return
     if (matchMedia('(prefers-reduced-motion: reduce)').matches) { before = new Map(); return }
@@ -131,21 +133,14 @@
       if (burst && (verb === 'breakpop' || verb === 'mine')) {
         setTimeout(() => {
           if (node.dataset.flightSeq === flightSeq) fx.land(from.rect, 'breakpop', [pieceColor(uid)])
-        }, options.delay + options.duration * (verb === 'mine' ? 0.28 : 0.42))
-      }
-      // a screwing nut flies bare, then THREADS: the descent beat of the screw
-      // keyframes (offset .52) is where the rod appears through it and it turns
-      if (verb === 'screw') {
-        setTimeout(() => {
-          if (node.dataset.flightSeq === flightSeq && node.classList.contains('flying')) node.classList.add('threading')
-        }, options.delay + options.duration * 0.52)
+        }, options.delay + options.duration * (verb === 'mine' ? 0.32 : 0.42))
       }
       anim.finished.then(() => {
         if (node.dataset.flightSeq !== flightSeq) return
-        node.classList.remove('flying', 'threading')
+        node.classList.remove('flying')
         if (burst) fx.land(node.getBoundingClientRect(), verb, artColors())
       }).catch(() => {
-        if (node.dataset.flightSeq === flightSeq) node.classList.remove('flying', 'threading')
+        if (node.dataset.flightSeq === flightSeq) node.classList.remove('flying')
       })
       trips.push({ from: from.rect, to, svg: node.innerHTML, color: pieceColor(uid) })
       index += 1
@@ -205,6 +200,7 @@
   bind:this={boardEl}
   data-skin={store.skin.key}
   style:--side="{side}px"
+  style:--item-h="{side * (store.skin.pieceRatio ?? 1)}px"
   style:--tube-h="{tubeH}px"
   style:background={store.theme?.tint}
   aria-label="sorting board"
@@ -228,7 +224,7 @@
               data-uid={item.uid}
               data-verb={verbFor(item)}
             >
-              <svg viewBox="0 0 64 64" aria-hidden="true">{@html artFor(item)}</svg>
+              <svg viewBox={store.skin.pieceViewBox ?? '0 0 64 64'} aria-hidden="true">{@html artFor(item)}</svg>
             </span>
           {/each}
         </button>

--- a/src/lib/ui/actors.js
+++ b/src/lib/ui/actors.js
@@ -16,14 +16,14 @@ function el(tag, cls, html) {
   return node
 }
 
-// a stone pickaxe: wooden haft, iron head. drawn with the haft end at the
-// origin so a rotation swings it like a real one.
+// a pixel pickaxe: one readable steel head and a square wooden haft. the old
+// curved head became a grey blob at phone size; hard steps survive scaling.
 const PICKAXE =
-  `<svg viewBox="-4 -60 68 68" aria-hidden="true">` +
-  `<path d="M0 0 L38 -38" stroke="#7A5233" stroke-width="7" stroke-linecap="round"/>` +
-  `<path d="M0 0 L38 -38" stroke="#5A3A22" stroke-width="3" stroke-linecap="round" opacity=".6"/>` +
-  `<path d="M22 -54 Q40 -60 56 -40 Q46 -38 40 -40 Q44 -30 38 -20 Q30 -34 22 -54 Z" fill="#B9B9B9" stroke="${INK}" stroke-width="2.4" stroke-linejoin="round"/>` +
-  `<path d="M26 -50 Q38 -52 48 -42" stroke="#E6E6E6" stroke-width="2" fill="none" stroke-linecap="round"/>` +
+  `<svg viewBox="0 0 72 72" aria-hidden="true" shape-rendering="crispEdges">` +
+  `<path d="M8 66 L4 62 L48 18 L54 24 L12 68 Z" fill="#7A5233" stroke="${INK}" stroke-width="2" stroke-linejoin="round"/>` +
+  `<path d="M10 60 L46 24 L49 27 L13 63 Z" fill="#B77A45"/>` +
+  `<path d="M18 8 H48 L67 21 L61 28 L46 18 H25 L12 31 L5 24 Z" fill="#BFC8CE" stroke="${INK}" stroke-width="2.5" stroke-linejoin="round"/>` +
+  `<path d="M23 11 H47 L58 19 H49 L44 16 H25 L17 24 H11 Z" fill="#EDF2F4" opacity=".85"/>` +
   `</svg>`
 
 // the visitor: tall, thin, dark, with glowing violet eyes and long arms that
@@ -73,26 +73,24 @@ export function mine(boardEl, trips, motion, hooks = {}) {
     layer.remove()
   }
 
-  // the pickaxe swings at each block from the top of the run down. a swing
-  // is three quick chops across the block's own shudder window (0 .. .28S)
+  // one decisive strike per block. one clear action reads better than the old
+  // three-hit flutter and keeps a multi-block move from feeling like a queue.
   for (let k = n - 1; k >= 0; k--) {
     const at = rel(trips[k].from)
     const pick = el('div', 'actor pickaxe', PICKAXE)
     // the haft's end sits just off the block's right shoulder so the head
     // swings down INTO the block rather than through it
-    pick.style.cssText = `left:${at.x + side * 0.8}px;top:${at.y - side * 0.25}px;width:${side * 1.1}px;height:${side * 1.1}px`
+    pick.style.cssText = `left:${at.x + side * 0.72}px;top:${at.y - side * 0.34}px;width:${side * 1.18}px;height:${side * 1.18}px`
     layer.appendChild(pick)
     const delay = (n - 1 - k) * d
     const a = pick.animate([
-      { transform: 'rotate(-60deg)', opacity: 0, offset: 0 },
-      { transform: 'rotate(-60deg)', opacity: 1, offset: 0.08 },
-      { transform: 'rotate(28deg)', offset: 0.32 },
-      { transform: 'rotate(-55deg)', offset: 0.5 },
-      { transform: 'rotate(28deg)', offset: 0.7 },
-      { transform: 'rotate(-55deg)', offset: 0.86 },
-      { transform: 'rotate(30deg)', opacity: 1, offset: 0.96 },
-      { transform: 'rotate(30deg)', opacity: 0, offset: 1 },
-    ], { duration: S * 0.3, delay, easing: 'linear', fill: 'both' })
+      { transform: 'rotate(-52deg) scale(.96)', opacity: 0, offset: 0 },
+      { transform: 'rotate(-52deg) scale(1)', opacity: 1, offset: 0.12 },
+      { transform: 'rotate(-62deg) scale(1)', opacity: 1, easing: 'ease-out', offset: 0.34 },
+      { transform: 'rotate(28deg) scale(1.04)', opacity: 1, easing: 'cubic-bezier(.7,0,1,.5)', offset: 0.72 },
+      { transform: 'rotate(24deg) scale(1)', opacity: 1, offset: 0.84 },
+      { transform: 'rotate(24deg) scale(1)', opacity: 0, offset: 1 },
+    ], { duration: S * 0.38, delay, easing: 'linear', fill: 'both' })
     animations.push(a)
     settled.push(a.finished)
   }
@@ -108,9 +106,9 @@ export function mine(boardEl, trips, motion, hooks = {}) {
   const h = side * 2.35
   who.style.cssText = `left:${src.x}px;top:${src.y + side - h}px;width:${side}px;height:${h}px`
   layer.appendChild(who)
-  const appear = S * 0.3 + (n - 1) * d
-  const arrive = S * 0.8
-  const gone = S * 0.86 + n * d
+  const appear = S * 0.34 + (n - 1) * d
+  const arrive = S * 0.72
+  const gone = S * 0.82 + n * d
   const dx = dst.x - src.x
   const dy = (dst.y + side) - (src.y + side)
   const total = gone + S * 0.12

--- a/src/lib/ui/flight.js
+++ b/src/lib/ui/flight.js
@@ -21,15 +21,19 @@ export function flightKeyframes(verb, { dx, dy, peakRel, rimRel, spin }) {
   const end = settled(spin)
 
   switch (verb) {
-    case 'screw':
-      // arrive above the shaft, then wind down it: rotation runs through the
-      // whole descent at a steady rate, which is what sells the threading.
+    case 'screw': {
+      // back straight off the source thread, travel as a bare nut, then line
+      // up over the destination and wind straight down. the nested nut-band
+      // reverses with these same beats, so the motion reads mechanically.
+      const rise = Math.min(16, Math.max(7, Math.abs(peakRel - dy) * .12))
       return [
         { transform: `${start} rotate(0deg)`, easing: LAUNCH, offset: 0 },
-        { transform: `${peak(0.55)} rotate(${spin * 0.25}deg)`, easing: CRUISE, offset: 0.34 },
-        { transform: `translate(0px, ${rimRel}px) rotate(${spin * 0.45}deg)`, easing: 'linear', offset: 0.52 },
+        { transform: `translate(${dx}px, ${dy - rise}px) rotate(0deg)`, easing: 'ease-out', offset: 0.22 },
+        { transform: `translate(0px, ${Math.min(peakRel, rimRel - rise)}px) rotate(0deg)`, easing: CRUISE, offset: 0.58 },
+        { transform: `translate(0px, ${rimRel}px) rotate(0deg)`, easing: 'linear', offset: 0.72 },
         { transform: `translate(0px, 0px) rotate(${end}deg)`, offset: 1 },
       ]
+    }
     case 'bounce':
       // gravity landing: squash at touch, spring back
       return [
@@ -78,18 +82,17 @@ export function flightKeyframes(verb, { dx, dy, peakRel, rimRel, spin }) {
         { transform: 'translate(0px, 0px) rotate(0deg) scale(1)', opacity: 1, offset: 1 },
       ]
     case 'mine':
-      // the block is MINED: three shudders under the pickaxe (actors.js swings
-      // on the same beats), gone at .28, carried over unseen, set down at .82.
+      // the block is MINED: one impact under the pickaxe, gone at .32, carried
+      // over unseen, set down at .78. the actor tells the rest of the story.
       // the invisible position swap is the carrier's job, not the block's.
       return [
         { transform: `${start} rotate(0deg) scale(1)`, opacity: 1, offset: 0 },
-        { transform: `translate(${dx - 3}px, ${dy + 1}px) rotate(-3deg) scale(1.02)`, opacity: 1, offset: 0.08 },
-        { transform: `translate(${dx + 3}px, ${dy - 1}px) rotate(3deg) scale(1)`, opacity: 1, offset: 0.16 },
-        { transform: `translate(${dx - 2}px, ${dy + 1}px) rotate(-3deg) scale(.96)`, opacity: 1, offset: 0.23 },
-        { transform: `${start} rotate(0deg) scale(.1)`, opacity: 0, offset: 0.28 },
-        { transform: 'translate(0px, 0px) rotate(0deg) scale(.1)', opacity: 0, offset: 0.29 },
-        { transform: 'translate(0px, 0px) rotate(0deg) scale(.1)', opacity: 0, offset: 0.82 },
-        { transform: 'translate(0px, 0px) rotate(0deg) scale(1.12)', opacity: 1, easing: 'ease-out', offset: 0.92 },
+        { transform: `translate(${dx - 3}px, ${dy + 1}px) rotate(-3deg) scale(1.03)`, opacity: 1, offset: 0.2 },
+        { transform: `translate(${dx + 2}px, ${dy - 1}px) rotate(2deg) scale(.9)`, opacity: .8, offset: 0.3 },
+        { transform: `${start} rotate(0deg) scale(.1)`, opacity: 0, offset: 0.32 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(.1)', opacity: 0, offset: 0.33 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(.1)', opacity: 0, offset: 0.78 },
+        { transform: 'translate(0px, 0px) rotate(0deg) scale(1.1)', opacity: 1, easing: 'ease-out', offset: 0.88 },
         { transform: 'translate(0px, 0px) rotate(0deg) scale(1)', opacity: 1, offset: 1 },
       ]
     case 'flip':
@@ -184,7 +187,7 @@ export function landingTimes(motion, count, verb = motion.land) {
   const beat = {
     screw: 0.52,
     breakpop: 0.76,
-    mine: 0.82,
+    mine: 0.78,
     flip: 0.82,
     roll: 0.88,
     fly: 1,

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -56,6 +56,17 @@ function verifyFlight(verb, motion, id) {
     }
   }
 
+  if (verb === 'screw') {
+    const backedOff = translateOf(keyframes[1].transform)
+    const linedUp = translateOf(keyframes.at(-2).transform)
+    if (!backedOff || backedOff.x !== GEO.dx || backedOff.y >= GEO.dy) {
+      fail(`${id}: nut does not back straight off the source post`)
+    }
+    if (!linedUp || linedUp.x !== 0 || linedUp.y !== GEO.rimRel) {
+      fail(`${id}: nut does not line up on the destination post before seating`)
+    }
+  }
+
   if (keyframes[0].offset !== 0) fail(`${id}: first offset is not 0`)
   if (keyframes.at(-1).offset !== 1) fail(`${id}: last offset is not 1`)
   let previous = -1
@@ -122,6 +133,14 @@ for (const skin of SKINS) {
   if (options.fill !== 'backwards') fail(`${id}: stagger does not hold the launch pose`)
   if (options.easing !== 'linear') fail(`${id}: effect easing would desync audio from keyframe offsets`)
 }
+
+const bolts = SKINS.find(skin => skin.key === 'bolts')
+if (bolts?.pieceRatio !== .625 || bolts?.pieceViewBox !== '0 0 64 40' || bolts?.tubeLip !== 22) {
+  fail('bolts: squat nut geometry contract drifted')
+}
+if ((bolts?.motion.seconds ?? 1) > .5) fail('bolts: single-nut move exceeds half a second')
+const mine = SKINS.find(skin => skin.key === 'mine')
+if ((mine?.motion.seconds ?? 2) >= 1) fail('mine: performance is no longer sub-one-second')
 
 if (failures) {
   console.error(`${failures} conversion/flight problem(s)`)


### PR DESCRIPTION
Closes the nuts-and-bolts and Block Mine motion slice of #29.

## What changed

- gives every tube one continuous threaded post instead of drawing a rod through every nut
- compacts nuts to a squat 64x40 profile with no stack gaps while retaining shape cues for color-blind play
- makes moves visibly back off the source, travel over, align, and screw onto the destination in 0.48s
- replaces the soft pickaxe art with a crisp pixel-style tool and reduces Block Mine to one fast, readable strike and carrier pass
- cancels visual performances safely on Undo, reset, or skin changes

## Proof

- 393x852 browser measurement: 64x40 nuts, zero vertical gap across a three-nut stack, zero per-piece rods
- immediate Undo: zero actors, zero flying pieces, zero effect layers, move count restored
- mid-performance skin change: zero actors, zero flying pieces, zero effect layers
- `npm run svelte-check`: 0 errors, 0 warnings
- `node tools/verify-flight.mjs`: 6 conversions, 11 verbs, 60 custom pieces proven
- `npm run lint:copy`: clean
- `npm run build`: green

The build still reports the existing Svelte initial-value warning in `store.svelte.js`; this change does not touch that code.
