### PR TITLE
mine: keep edge strikes inside the board

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -359,6 +359,8 @@ h1 {
 .actor { position: absolute; will-change: transform, opacity; }
 .actor svg { display: block; width: 100%; height: 100%; overflow: visible; }
 .actor.pickaxe { transform-origin: 6% 94%; filter: drop-shadow(0 2px 2px rgb(0 0 0 / .4)); }
+.actor.pickaxe.from-left { transform-origin: 94% 94%; }
+.actor.pickaxe.from-left svg { transform: scaleX(-1); }
 .actor.visitor { filter: drop-shadow(0 4px 3px rgb(0 0 0 / .45)); }
 
 /* neon dash: dark grid, glowing lanes, icons with their own glow. an

--- a/src/lib/ui/actors.js
+++ b/src/lib/ui/actors.js
@@ -78,18 +78,25 @@ export function mine(boardEl, trips, motion, hooks = {}) {
   for (let k = n - 1; k >= 0; k--) {
     const at = rel(trips[k].from)
     const pick = el('div', 'actor pickaxe', PICKAXE)
-    // the haft's end sits just off the block's right shoulder so the head
-    // swings down INTO the block rather than through it
-    pick.style.cssText = `left:${at.x + side * 0.72}px;top:${at.y - side * 0.34}px;width:${side * 1.18}px;height:${side * 1.18}px`
+    // keep the whole swing inside the board: a right-edge block is struck
+    // from its left shoulder with the same tool mirrored mechanically.
+    const fromLeft = at.x + side * 1.9 > board.width
+    if (fromLeft) pick.classList.add('from-left')
+    const left = fromLeft ? at.x - side * 0.9 : at.x + side * 0.72
+    const ready = fromLeft ? 52 : -52
+    const windup = fromLeft ? 62 : -62
+    const impact = fromLeft ? -28 : 28
+    const rest = fromLeft ? -24 : 24
+    pick.style.cssText = `left:${left}px;top:${at.y - side * 0.34}px;width:${side * 1.18}px;height:${side * 1.18}px`
     layer.appendChild(pick)
     const delay = (n - 1 - k) * d
     const a = pick.animate([
-      { transform: 'rotate(-52deg) scale(.96)', opacity: 0, offset: 0 },
-      { transform: 'rotate(-52deg) scale(1)', opacity: 1, offset: 0.12 },
-      { transform: 'rotate(-62deg) scale(1)', opacity: 1, easing: 'ease-out', offset: 0.34 },
-      { transform: 'rotate(28deg) scale(1.04)', opacity: 1, easing: 'cubic-bezier(.7,0,1,.5)', offset: 0.72 },
-      { transform: 'rotate(24deg) scale(1)', opacity: 1, offset: 0.84 },
-      { transform: 'rotate(24deg) scale(1)', opacity: 0, offset: 1 },
+      { transform: `rotate(${ready}deg) scale(.96)`, opacity: 0, offset: 0 },
+      { transform: `rotate(${ready}deg) scale(1)`, opacity: 1, offset: 0.12 },
+      { transform: `rotate(${windup}deg) scale(1)`, opacity: 1, easing: 'ease-out', offset: 0.34 },
+      { transform: `rotate(${impact}deg) scale(1.04)`, opacity: 1, easing: 'cubic-bezier(.7,0,1,.5)', offset: 0.72 },
+      { transform: `rotate(${rest}deg) scale(1)`, opacity: 1, offset: 0.84 },
+      { transform: `rotate(${rest}deg) scale(1)`, opacity: 0, offset: 1 },
     ], { duration: S * 0.38, delay, easing: 'linear', fill: 'both' })
     animations.push(a)
     settled.push(a.finished)


### PR DESCRIPTION
Follow-up to #29 and #40.

The live 393x852 check found that a pickaxe striking the far-right tube could rotate outside the viewport. This mirrors the same pixel tool and its swing to the block's left shoulder whenever a right-side strike would cross the board edge.

Proof:

- far-right strike: `actor pickaxe from-left`, measured bounds 200.4-306.1 inside a 393px viewport
- left-side strike: original direction, measured bounds 86.9-192.6 inside the viewport
- both performances settle to zero actors and zero flying pieces
- `npm run svelte-check`: 0 errors, 0 warnings
- `node tools/verify-flight.mjs`, copy lint, and release build: green

The build still reports the existing Svelte initial-value warning in `store.svelte.js`; this change does not touch that code.
