### PR TITLE
Seat overlapping nuts on the bolt

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -287,13 +287,15 @@ h1 {
   border-radius: 0;
   background: transparent;
 }
-/* the bolt: a straight threaded rod, flat on top (a bolt, not a screw), and
-   narrow enough to stay inside the nuts' central bore. */
+#board[data-skin="bolts"] { gap: 2px; }
+#board[data-skin="bolts"] .row { gap: 2px; }
+/* the bolt: a straight threaded rod, flat on top (a bolt, not a screw). it
+   lives behind the opaque nut shells and protrudes above the occupied stack. */
 [data-skin="bolts"] .tube::before {
   content: '';
   position: absolute;
   inset: 0 auto 6px 50%;
-  width: calc(var(--side, 44px) * 19 / 64);
+  width: calc(var(--side, 44px) * 22 / 64);
   translate: -50% 0;
   background:
     linear-gradient(90deg, rgb(255 255 255 / .6), rgb(255 255 255 / 0) 40%, rgb(0 0 0 / .32) 100%),
@@ -302,6 +304,7 @@ h1 {
   border-bottom: 0;
   border-radius: 50% 50% 0 0 / 6px 6px 0 0;
   box-shadow: 4px 0 6px -3px rgb(61 50 48 / .45), inset 0 3px 0 rgb(255 255 255 / .35);
+  z-index: 0;
 }
 [data-skin="bolts"] .tube::after { /* the washer the column stands on */
   content: '';
@@ -314,7 +317,8 @@ h1 {
   border-radius: 50%;
 }
 [data-skin="bolts"] .tube { border-bottom-color: transparent; }
-[data-skin="bolts"] .item { position: relative; z-index: 1; padding: 0; filter: drop-shadow(0 3px 2px rgb(42 34 32 / .35)); }
+[data-skin="bolts"] .item { position: relative; z-index: var(--stack-depth, 1); padding: 0; filter: drop-shadow(0 2px 1px rgb(42 34 32 / .28)); }
+[data-skin="bolts"] .item.flying { z-index: 30; }
 [data-skin="bolts"] .item svg { overflow: visible; }
 /* the tube owns the only post. the nut owns only its turning side band: first
    it backs off the source thread, holds while crossing, then winds onto the
@@ -324,8 +328,8 @@ h1 {
 }
 @keyframes nutspin {
   from { transform: translateX(0); }
-  22% { transform: translateX(112px); }
-  58% { transform: translateX(112px); }
+  22% { transform: translateX(calc(var(--side, 44px) * -62 / 64)); }
+  58% { transform: translateX(calc(var(--side, 44px) * -62 / 64)); }
   to { transform: translateX(0); }
 }
 [data-skin="bolts"] .tube.sel { box-shadow: none; }

--- a/src/lib/engine/skinart/bolts.js
+++ b/src/lib/engine/skinart/bolts.js
@@ -1,23 +1,22 @@
-// nuts & bolts pieces: twelve coloured hex nuts seen in three-quarter view,
-// the way they sit on a real bolt: a lit top face with the bore showing,
-// then the side faces below it carrying a small white mark for anyone who
-// does not read colour. the nut IS the piece, no theme face on top.
+// nuts & bolts pieces: twelve chunky front-on hex nuts wrapped around one
+// tube-owned post. this is the physical read of the reference: the post only
+// protrudes above the stack; an occupied section is completely inside a nut.
+// a white mark keeps every nut distinct without relying on colour alone.
 //
 // the side faces live in a wide band under a clip. app.css slides that band
 // sideways while a nut is flying, so a nut screwing down the post visibly
 // TURNS about the bolt instead of tumbling in the plane of the screen.
-// drawn for a viewBox of 0 0 64 40. the short viewBox is deliberate: a nut
-// is squat hardware, not a square game tile. Board uses the skin's pieceRatio
-// so these stack tightly on one continuous tube-owned post.
+// drawn for a viewBox of 0 0 64 40. the painted nut deliberately bleeds five
+// units above and below that box: the upper shell covers the top edge of the
+// lower shell, the way two nuts seated directly together actually read.
 //
 // every piece module in skinart/ exports the same shape:
 //   { pieces: [12 x { key, color, svg }], hidden: svg }
 
-// the flattened hexagon of the top face, and the body below it
-const TOP = 'M4 10 L16 1 L48 1 L60 10 L48 19 L16 19 Z'
-const BODY = 'M4 10 L4 29 L16 39 L48 39 L60 29 L60 10 L48 19 L16 19 Z'
-// one period of the band: a lit side face, the front face, a shaded side
-// face (14 + 28 + 14 = 56 units). a full turn of the nut is two periods.
+const SHELL = 'M1 4 L9 -5 H55 L63 4 V36 L55 45 H9 L1 36 Z'
+// one period of the turning shell: a lit side, broad front, and shaded side
+// (11 + 40 + 11 = 62 units). app.css slides one full period while the piece
+// travels; repeated periods make that a seamless rotation about the post.
 
 // the twelve marks, each centred at (0,0) in a 16-unit box
 const MARKS = {
@@ -55,37 +54,28 @@ function nut(key, face, lit, shade, mark) {
   const id = `nut-${key}`
   // one period of side faces; the mark rides the front face only
   const period = (x) =>
-    `<rect x="${x}" y="10" width="14" height="29" fill="${lit}"/>` +
-    `<rect x="${x + 14}" y="10" width="28" height="29" fill="${face}"/>` +
-    `<rect x="${x + 42}" y="10" width="14" height="29" fill="${shade}"/>` +
-    `<path d="${MARKS[mark]}" fill="#fff" opacity=".92" transform="translate(${x + 28} 28) scale(.82)"/>`
+    `<rect x="${x}" y="-5" width="11" height="50" fill="${lit}"/>` +
+    `<rect x="${x + 11}" y="-5" width="40" height="50" fill="${face}"/>` +
+    `<rect x="${x + 51}" y="-5" width="11" height="50" fill="${shade}"/>` +
+    `<path d="${MARKS[mark]}" fill="#fff" opacity=".94" transform="translate(${x + 31} 21) scale(.9)"/>`
   return (
     `<defs>` +
-    `<clipPath id="${id}-c"><path d="${BODY}"/></clipPath>` +
-    `<linearGradient id="${id}-t" x1="0" y1="0" x2="1" y2="1">` +
-    `<stop offset="0" stop-color="#fff" stop-opacity=".85"/><stop offset=".5" stop-color="${lit}"/><stop offset="1" stop-color="${face}"/>` +
-    `</linearGradient>` +
+    `<clipPath id="${id}-c"><path d="${SHELL}"/></clipPath>` +
     `</defs>` +
-    // the side faces: a band three periods wide, clipped to the body. the
+    // the shell: a band three periods wide, clipped to the nut. the
     // band starts one period left so the front face sits centre at rest.
     `<g clip-path="url(#${id}-c)">` +
-    `<g class="nut-band">${period(-52)}${period(4)}${period(60)}</g>` +
-    // the bottom bevel and a soft vertical shading over the whole body
-    `<path d="M4 33 L4 29 L16 39 L48 39 L60 29 L60 33 L48 40 L16 40 Z" fill="#000" opacity=".22"/>` +
-    `<rect x="4" y="10" width="56" height="29" fill="url(#${id}-v)"/>` +
+    `<g class="nut-band">${period(-61)}${period(1)}${period(63)}</g>` +
+    // machined bevels sell the thickness without exposing a fake top hole
+    `<path d="M1 4 L9 -5 H55 L63 4 L55 10 H9 Z" fill="#fff" opacity=".28"/>` +
+    `<path d="M1 36 L9 45 H55 L63 36 L55 30 H9 Z" fill="#000" opacity=".2"/>` +
+    `<rect x="1" y="-5" width="62" height="50" fill="url(#${id}-v)"/>` +
     `</g>` +
     `<defs><linearGradient id="${id}-v" x1="0" y1="0" x2="0" y2="1">` +
-    `<stop offset="0" stop-color="#fff" stop-opacity=".18"/><stop offset=".5" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity=".18"/>` +
+    `<stop offset="0" stop-color="#fff" stop-opacity=".12"/><stop offset=".48" stop-color="#fff" stop-opacity="0"/><stop offset="1" stop-color="#000" stop-opacity=".14"/>` +
     `</linearGradient></defs>` +
-    // the top face, lit from the upper left, and the threaded bore
-    `<path d="${TOP}" fill="url(#${id}-t)"/>` +
-    `<ellipse cx="32" cy="10" rx="10" ry="4.8" fill="#2E2A27"/>` +
-    `<ellipse cx="32" cy="9.6" rx="7" ry="3.1" fill="#A8A19A" stroke="#625B55" stroke-width="1" stroke-dasharray="2 1.4"/>` +
-    `<ellipse cx="30" cy="8.8" rx="3.8" ry="1.1" fill="#fff" opacity=".38"/>` +
-    // the edges
-    `<path d="${TOP}" fill="none" stroke="#2A2220" stroke-width="2" stroke-linejoin="round"/>` +
-    `<path d="M4 10 L4 29 L16 39 L48 39 L60 29 L60 10" fill="none" stroke="#2A2220" stroke-width="2.2" stroke-linejoin="round"/>` +
-    `<path d="M16 19 L16 39 M48 19 L48 39" stroke="#2A2220" stroke-width="1.2" opacity=".55"/>`
+    `<path class="nut-shell" d="${SHELL}" fill="none" stroke="#2A2220" stroke-width="2.2" stroke-linejoin="round"/>` +
+    `<path d="M9 10 V30 M55 10 V30" stroke="#2A2220" stroke-width="1.2" opacity=".5"/>`
   )
 }
 
@@ -93,6 +83,6 @@ export default {
   pieces: NUTS.map(([key, face, lit, shade, mark]) => ({ key: `${key} nut`, color: face, svg: nut(key, face, lit, shade, mark) })),
   // a mystery nut: dull unfinished steel, a question mark on the front face
   hidden: nut('hid', '#A39B93', '#D9D3CC', '#5E5751', 'dot')
-    .replace(/<path d="[^"]*" fill="#fff" opacity="\.92" transform="translate\(32 28\) scale\(\.82\)"\/>/,
-      `<path d="M-4 -5 Q-4 -10 0 -10 Q4 -10 4 -6 Q4 -3 1 -2 L1 0" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" transform="translate(32 29) scale(.82)"/><circle cx="32.8" cy="32.5" r="1.4" fill="#fff"/>`),
+    .replace(/<path d="[^"]*" fill="#fff" opacity="\.94" transform="translate\(32 21\) scale\(\.9\)"\/>/,
+      `<path d="M-4 -5 Q-4 -10 0 -10 Q4 -10 4 -6 Q4 -3 1 -2 L1 0" stroke="#fff" stroke-width="2.6" fill="none" stroke-linecap="round" transform="translate(32 20) scale(.9)"/><circle cx="32.9" cy="25" r="1.5" fill="#fff"/>`),
 }

--- a/src/lib/engine/skins.js
+++ b/src/lib/engine/skins.js
@@ -34,7 +34,7 @@ export const SKINS = [
     hidden: bolts.hidden,
     pieceRatio: .625,
     pieceViewBox: '0 0 64 40',
-    tubeLip: 22,
+    tubeLip: 34,
     // spin 0: the nut turns about the bolt via its own side band (app.css
     // nutspin), a planar rotate would read as tumbling in three-quarter view
     motion: { seconds: .48, lift: .75, spin: 0, stagger: .06, land: 'screw' },

--- a/src/lib/ui/Board.svelte
+++ b/src/lib/ui/Board.svelte
@@ -216,13 +216,14 @@
           onclick={() => store.tap(index)}
           aria-label={tubeLabel(index)}
         >
-          {#each store.tubes[index] as item (item.uid)}
+          {#each store.tubes[index] as item, itemIndex (item.uid)}
             <span
               class="item"
               class:hid={item.hid}
               class:lift={isLifted(index, item)}
               data-uid={item.uid}
               data-verb={verbFor(item)}
+              style:--stack-depth={itemIndex + 1}
             >
               <svg viewBox={store.skin.pieceViewBox ?? '0 0 64 64'} aria-hidden="true">{@html artFor(item)}</svg>
             </span>

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -14,6 +14,7 @@ const VERBS = new Set(['drop', 'screw', 'breakpop', 'mine', 'flip', 'roll', 'fly
 const MATERIALS = new Set(['metal', 'stone', 'neon', 'pop', 'cute', 'dice'])
 const CONVERSIONS = ['bolts', 'mine', 'dash', 'kawaii', 'dice', 'tubes']
 const CSS = readFileSync(new URL('../src/app.css', import.meta.url), 'utf8')
+const BOARD = readFileSync(new URL('../src/lib/ui/Board.svelte', import.meta.url), 'utf8')
 
 const translateOf = transform => {
   const match = /translate\((-?[\d.]+)px,\s*(-?[\d.]+)px\)/.exec(transform)
@@ -135,10 +136,20 @@ for (const skin of SKINS) {
 }
 
 const bolts = SKINS.find(skin => skin.key === 'bolts')
-if (bolts?.pieceRatio !== .625 || bolts?.pieceViewBox !== '0 0 64 40' || bolts?.tubeLip !== 22) {
+if (bolts?.pieceRatio !== .625 || bolts?.pieceViewBox !== '0 0 64 40' || bolts?.tubeLip !== 34) {
   fail('bolts: squat nut geometry contract drifted')
 }
 if ((bolts?.motion.seconds ?? 1) > .5) fail('bolts: single-nut move exceeds half a second')
+for (const [index, piece] of (bolts?.pieces ?? []).entries()) {
+  if (!piece.svg.includes('class="nut-shell"')) fail(`bolts: piece ${index} has no mounted shell`)
+  if (piece.svg.includes('nut-bore') || /<ellipse\b/.test(piece.svg)) fail(`bolts: piece ${index} exposes a fake top hole`)
+  const shell = /class="nut-shell" d="([^"]+)"/.exec(piece.svg)?.[1] ?? ''
+  if (!shell.includes('L9 -5') || !shell.includes('L55 45')) fail(`bolts: piece ${index} no longer overlaps the nut below`)
+}
+if (!CSS.includes('#board[data-skin="bolts"] { gap: 2px; }')) fail('bolts: row gap is no longer compact')
+if (!CSS.includes('* -62 / 64')) fail('bolts: the side band no longer completes a scaled mechanical turn')
+if (!CSS.includes('z-index: var(--stack-depth, 1)')) fail('bolts: upper nuts no longer paint over lower nuts')
+if (!BOARD.includes('style:--stack-depth={itemIndex + 1}')) fail('bolts: stack order no longer puts upper nuts in front')
 const mine = SKINS.find(skin => skin.key === 'mine')
 if ((mine?.motion.seconds ?? 2) >= 1) fail('mine: performance is no longer sub-one-second')
 


### PR DESCRIPTION
Refs #29

- redraw nuts in the front-on mounted style from the supplied reference
- remove fake top holes and leave threaded post protruding above occupied stacks
- overlap every nut by 10 SVG units; explicit stack depth makes the upper nut cover the top edge below
- retain the 0.48s mechanical face twist
- compact spacing between posts

Proof:
- iPhone viewport 393x852 visual pass
- runtime: 40-unit pitch, shell paints -5..45, z-index rises 1..4
- runtime: nutspin active at 0.48s with a nonzero mid-turn transform
- overlap mutant fails 12/12 pieces
- npm run verify
- npm run svelte-check
- npm run lint:copy
- npm run build