### PR TITLE
bolts: orient the carriage heads upward

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -289,32 +289,34 @@ h1 {
 }
 #board[data-skin="bolts"] { gap: 2px; }
 #board[data-skin="bolts"] .row { gap: 2px; }
-/* the bolt: a straight threaded rod, flat on top (a bolt, not a screw). it
-   lives behind the opaque nut shells and protrudes above the occupied stack. */
+/* the bolt points upward: a straight threaded shaft rises from the underside
+   of its carriage head. it stays behind the opaque nut shells. */
 [data-skin="bolts"] .tube::before {
   content: '';
   position: absolute;
-  inset: 0 auto 6px 50%;
+  inset: 0 auto 11px 50%;
   width: calc(var(--side, 44px) * 22 / 64);
   translate: -50% 0;
   background:
     linear-gradient(90deg, rgb(255 255 255 / .6), rgb(255 255 255 / 0) 40%, rgb(0 0 0 / .32) 100%),
-    repeating-linear-gradient(180deg, #D3CCC4 0 calc(var(--side, 44px) * 3 / 64), #8F877F calc(var(--side, 44px) * 3 / 64) calc(var(--side, 44px) * 5 / 64), #6E665F calc(var(--side, 44px) * 5 / 64) calc(var(--side, 44px) * 6 / 64));
+    repeating-linear-gradient(168deg, #D3CCC4 0 calc(var(--side, 44px) * 3 / 64), #8F877F calc(var(--side, 44px) * 3 / 64) calc(var(--side, 44px) * 5 / 64), #6E665F calc(var(--side, 44px) * 5 / 64) calc(var(--side, 44px) * 6 / 64));
   border: 2px solid var(--line);
   border-bottom: 0;
   border-radius: 50% 50% 0 0 / 6px 6px 0 0;
   box-shadow: 4px 0 6px -3px rgb(61 50 48 / .45), inset 0 3px 0 rgb(255 255 255 / .35);
-  z-index: 0;
+  z-index: 1;
 }
-[data-skin="bolts"] .tube::after { /* the washer the column stands on */
+[data-skin="bolts"] .tube::after { /* underside of the carriage-bolt head */
   content: '';
   position: absolute;
-  bottom: -4px; left: 50%;
-  width: 96%; height: 14px;
+  bottom: -5px; left: 50%;
+  width: 96%; height: 18px;
   translate: -50% 0;
-  background: radial-gradient(ellipse at 40% 35%, #E4DED7, #A29A92 70%, #7A736C);
+  background: radial-gradient(ellipse at 50% 78%, #EEEAE5, #C0B9B2 45%, #8D847D 72%, #625B55 100%);
   border: 2px solid var(--line);
   border-radius: 50%;
+  box-shadow: inset 0 3px 0 rgb(55 48 45 / .38), inset 0 -2px 0 rgb(255 255 255 / .22), 0 2px 2px rgb(55 48 45 / .18);
+  z-index: 0;
 }
 [data-skin="bolts"] .tube { border-bottom-color: transparent; }
 [data-skin="bolts"] .item { position: relative; z-index: var(--stack-depth, 1); padding: 0; filter: drop-shadow(0 2px 1px rgb(42 34 32 / .28)); }

--- a/tools/verify-flight.mjs
+++ b/tools/verify-flight.mjs
@@ -151,6 +151,10 @@ if (!CSS.includes('#board[data-skin="bolts"] { gap: 2px; }')) fail('bolts: row g
 if (!CSS.includes('* -62 / 64')) fail('bolts: the side band no longer completes a scaled mechanical turn')
 if (!CSS.includes('z-index: var(--stack-depth, 1)')) fail('bolts: upper nuts no longer paint over lower nuts')
 if (!BOARD.includes('style:--stack-depth={itemIndex + 1}')) fail('bolts: stack order no longer puts upper nuts in front')
+const boltShaft = /\[data-skin="bolts"\] \.tube::before \{([\s\S]*?)\n\}/.exec(CSS)?.[1] ?? ''
+const boltHead = /\[data-skin="bolts"\] \.tube::after \{([\s\S]*?)\n\}/.exec(CSS)?.[1] ?? ''
+if (!boltShaft.includes('repeating-linear-gradient(168deg')) fail('bolts: shaft threads no longer read as a helix')
+if (!boltShaft.includes('z-index: 1') || !boltHead.includes('z-index: 0')) fail('bolts: carriage head no longer sits behind its shaft')
 const mine = SKINS.find(skin => skin.key === 'mine')
 if ((mine?.motion.seconds ?? 2) >= 1) fail('mine: performance is no longer sub-one-second')
 const middleStrike = pickaxeSwing(80, 40, 320)


### PR DESCRIPTION
Refs #29

- paint the threaded shaft above the carriage-head underside
- run angled helical threads down to the head connection
- relight and deepen the head so its underside faces the player
- guard thread direction and shaft/head depth ordering

Verified: npm run verify; npm run svelte-check; npm run build; npm run lint:copy; 430x932 browser passes at levels 1 and 29 with no console errors.