### PR TITLE
start the clock on the first move and hold it under every dialog

### DIFF
--- a/src/lib/ui/play-clock.js
+++ b/src/lib/ui/play-clock.js
@@ -30,6 +30,37 @@ export function createPlayClock(now = () => Date.now()) {
       stoppedAt = pausedAt ?? now()
       pausedAt = null
     },
+    clear() {
+      startedAt = pausedAt = stoppedAt = null
+    },
+  }
+}
+
+// The game's clock: a play clock plus the rule for when it may run. It starts
+// on the first move, not when the board opens, and it runs only while a live
+// board is the thing on screen: not under a dialog, not behind the levels
+// screen, not in a hidden tab, not after a win. Every gate change re-derives
+// run/pause from the whole set, so releasing one gate (closing help) never
+// restarts a clock that another gate (a hidden tab) still holds.
+export function createSessionClock(now = () => Date.now()) {
+  const clock = createPlayClock(now)
+  const gates = { hidden: false, overlay: false, away: false }
+  let started = false
+  const sync = () => {
+    if (!started) return
+    if (gates.hidden || gates.overlay || gates.away) clock.pause()
+    else clock.resume()
+  }
+  return {
+    // a fresh board: nothing on the clock until the first move
+    reset() { started = false; clock.clear() },
+    // a board that already has moves on it comes back with its time, held
+    // until every gate says play is on screen
+    restore(elapsed) { started = true; clock.start(elapsed, true); sync() },
+    begin() { if (started) return; started = true; clock.start(0, true); sync() },
+    hold(gate, held) { gates[gate] = !!held; sync() },
+    finish() { clock.stop() },
+    elapsed: () => clock.elapsed(),
   }
 }
 

--- a/src/lib/ui/play-clock.js
+++ b/src/lib/ui/play-clock.js
@@ -60,6 +60,10 @@ export function createSessionClock(now = () => Date.now()) {
     begin() { if (started) return; started = true; clock.start(0, true); sync() },
     hold(gate, held) { gates[gate] = !!held; sync() },
     finish() { clock.stop() },
+    // undoing a win: the board is live again, so the stopped time becomes a
+    // running clock, still held by whatever gate is up
+    reopen() { if (!started) return; clock.start(clock.elapsed(), true); sync() },
+    started: () => started,
     elapsed: () => clock.elapsed(),
   }
 }

--- a/src/lib/ui/store.svelte.js
+++ b/src/lib/ui/store.svelte.js
@@ -12,7 +12,7 @@ import { dailySeed } from '../engine/seed.js'
 import { sound } from './sounds.js'
 import { confetti } from './confetti.js'
 import { landingTimes } from './flight.js'
-import { createPlayClock, formatPlayTime } from './play-clock.js'
+import { createSessionClock, formatPlayTime } from './play-clock.js'
 
 export { LEVEL_COUNT, WORLD_SIZE, WORLD_COUNT }
 
@@ -77,7 +77,7 @@ export function createStore() {
   let history = []                  // undo snapshots (not reactive: read only on undo)
   let seen = new Set()
   let uidNext = 0
-  const playClock = createPlayClock()
+  const playClock = createSessionClock()
   let dialog = $state(null)         // 'howto' | 'looks' | 'about' | null
   let hintTubes = $state([])        // indices the hint button flashes
   let moveSeq = $state(0)           // bumps each move so Board runs its FLIP
@@ -91,6 +91,8 @@ export function createStore() {
     clockText = formatPlayTime(playClock.elapsed())
   }
   if (typeof window !== 'undefined') setInterval(tick, 500)
+  // a tab restored in the background boots hidden; the page reports later changes
+  if (typeof document !== 'undefined') playClock.hold('hidden', document.hidden)
 
   function revealTops(changed) {
     let revealed = false
@@ -134,7 +136,7 @@ export function createStore() {
 
   function finishWin() {
     over = true
-    playClock.stop()
+    playClock.finish()
     tick()
     const stars = starsFor(moves, board.par, board.solution.length)
     let detail = `sorted in ${moves} moves, ${clockText}!`
@@ -191,7 +193,8 @@ export function createStore() {
       moves = Number.isInteger(raw.moves) && raw.moves >= 0 ? raw.moves : 0
       history = Array.isArray(raw.history) ? raw.history : []
       seen = new Set(Array.isArray(raw.seen) ? raw.seen : [])
-      playClock.start(Number.isFinite(raw.elapsed) && raw.elapsed > 0 ? raw.elapsed : 0, document.hidden)
+      // a board nobody has moved on yet has no time on it, whatever was saved
+      if (moves > 0) playClock.restore(Number.isFinite(raw.elapsed) && raw.elapsed > 0 ? raw.elapsed : 0)
       tick()
       stuck = !anyPlayerMove()
       return true
@@ -221,6 +224,7 @@ export function createStore() {
     next[move.to] = next[move.to].concat(next[move.from].splice(next[move.from].length - move.count, move.count))
     tubes = next
     selected = null
+    playClock.begin()
     moves += 1
     moveSeq += 1
     revealTops(true)
@@ -256,10 +260,11 @@ export function createStore() {
     stuck = false
     won = null
     seen = new Set()
-    playClock.start(0, typeof document !== 'undefined' && document.hidden)
+    playClock.reset()
     clockText = '0:00'
     revealTops(false)
     screen = 'game'
+    playClock.hold('away', false)
     // par is computed off the critical path so the board paints first. the guard has
     // to be a TOKEN, not object identity: `board` is $state, so `board = b` stores a
     // reactive PROXY and `board === b` is always false, which silently dropped every
@@ -307,11 +312,11 @@ export function createStore() {
     isTubeDone: t => isComplete(colorsOf(t), capacity) && !t.some(i => i.hid),
     goGame() {
       screen = 'game'
-      if (typeof document === 'undefined' || !document.hidden) playClock.resume()
+      playClock.hold('away', false)
       tick()
     },
     openLevels() {
-      playClock.pause()
+      playClock.hold('away', true)
       tick()
       saveGame()
       world = Math.floor(((board?.kind === 'level' ? board.n : progress.current) - 1) / WORLD_SIZE)
@@ -353,17 +358,12 @@ export function createStore() {
       saveSkin(next)
     },
     setShellTheme(next) { shellTheme = next; saveTheme(next.key); applyTheme(next) },
-    openDialog(d) { dialog = d },
-    closeDialog() { dialog = null },
+    openDialog(d) { dialog = d; playClock.hold('overlay', true); tick() },
+    closeDialog() { dialog = null; playClock.hold('overlay', false); tick() },
     setVisible(visible) {
-      if (!visible) {
-        playClock.pause()
-        tick()
-        saveGame()
-      } else if (screen === 'game' && !over) {
-        playClock.resume()
-        tick()
-      }
+      playClock.hold('hidden', !visible)
+      tick()
+      if (!visible) saveGame()
     },
     // two tabs writing one store: adopt the better of the two rather than clobber
     mergeExternalProgress() {

--- a/src/lib/ui/store.svelte.js
+++ b/src/lib/ui/store.svelte.js
@@ -172,7 +172,7 @@ export function createStore() {
       localStorage.setItem(GAME_KEY, JSON.stringify({
         kind: board.kind, n: board.n, seed: board.seed,
         tubes: $state.snapshot(tubes), moves, history,
-        elapsed: playClock.elapsed(),
+        started: playClock.started(), elapsed: playClock.elapsed(),
         seen: [...seen],
       }))
     } catch { /* a blocked store only costs the resume */ }
@@ -193,8 +193,11 @@ export function createStore() {
       moves = Number.isInteger(raw.moves) && raw.moves >= 0 ? raw.moves : 0
       history = Array.isArray(raw.history) ? raw.history : []
       seen = new Set(Array.isArray(raw.seen) ? raw.seen : [])
-      // a board nobody has moved on yet has no time on it, whatever was saved
-      if (moves > 0) playClock.restore(Number.isFinite(raw.elapsed) && raw.elapsed > 0 ? raw.elapsed : 0)
+      // a board nobody has moved on yet has no time on it, whatever was saved.
+      // undo can take a played board back to zero moves, so the save carries
+      // its own started bit; saves from before that bit only have the count
+      const started = typeof raw.started === 'boolean' ? raw.started : moves > 0
+      if (started) playClock.restore(Number.isFinite(raw.elapsed) && raw.elapsed > 0 ? raw.elapsed : 0)
       tick()
       stuck = !anyPlayerMove()
       return true
@@ -336,6 +339,7 @@ export function createStore() {
       for (const t of last.tubes) for (const it of t) if (seen.has(it.uid)) it.hid = false
       tubes = last.tubes
       selected = null
+      if (over) playClock.reopen()
       over = false
       moves = last.moves
       won = null

--- a/tools/verify-play-clock.mjs
+++ b/tools/verify-play-clock.mjs
@@ -163,6 +163,62 @@ now += 60_000
 store.setVisible(true)
 if (store.moves !== 1 || store.clock !== '1:04') fail(`a moved board did not reload with its time: ${store.clock}`)
 
+// a board undone back to zero moves has still been played: its time survives a reload
+store.startLevel(1)
+store.tap(0); store.tap(2)
+now += 5_000
+store.setVisible(true)
+store.undo()
+if (store.moves !== 0 || store.clock !== '0:05') fail(`undo to zero moves changed the clock: ${store.moves} moves, ${store.clock}`)
+store.setVisible(false)
+store = open()
+if (store.moves !== 0 || store.clock !== '0:05') fail(`a board undone to zero moves reloaded without its time: ${store.clock}`)
+
+// a save from before the started bit: zero moves means untouched, moves mean played
+const legacy = JSON.parse(stored.get('sortit:game'))
+delete legacy.started
+legacy.elapsed = 9_000
+stored.set('sortit:game', JSON.stringify(legacy))
+store = open()
+if (store.clock !== '0:00') fail(`an old untouched save reloaded with time on it: ${store.clock}`)
+legacy.moves = 1
+stored.set('sortit:game', JSON.stringify(legacy))
+store = open()
+if (store.clock !== '0:09') fail(`an old moved save did not reload with its time: ${store.clock}`)
+
+// undoing a win reopens the board, and the clock runs again on the next tick
+store.startLevel(1)
+solveOut(store)
+now += 3_000
+store.setVisible(true)
+if (!store.won || store.clock !== '0:00') fail(`the win did not stop the clock: ${store.clock}`)
+store.undo()
+now += 10_000
+store.setVisible(true)
+if (store.won || store.clock !== '0:10') fail(`undoing a win left the clock stopped: ${store.clock}`)
+
+// but not under a dialog, and not in a hidden tab
+const winAgain = () => { const m = store.board.solution.at(-1); store.tap(m.from); store.tap(m.to) }
+winAgain()
+store.openDialog('about')
+store.undo()
+now += 10_000
+store.setVisible(true)
+if (store.clock !== '0:10') fail(`undoing a win under a dialog ran the clock: ${store.clock}`)
+store.closeDialog()
+now += 1_000
+store.setVisible(true)
+if (store.clock !== '0:11') fail(`the reopened board did not resume once the dialog closed: ${store.clock}`)
+store.setVisible(false)
+winAgain()
+store.undo()
+now += 10_000
+if (store.clock !== '0:11') fail(`undoing a win in a hidden tab ran the clock: ${store.clock}`)
+store.setVisible(true)
+now += 1_000
+store.setVisible(true)
+if (store.clock !== '0:12') fail(`the reopened board did not resume once the tab showed: ${store.clock}`)
+
 const page = readFileSync(new URL('../src/routes/+page.svelte', import.meta.url), 'utf8')
 if (!page.includes('<button onclick={() => store.replay()}>RESET</button>')) fail('RESET is not a direct game control')
 if (!page.includes('store.setVisible(!document.hidden)')) fail('visibility is not wired to the play clock')

--- a/tools/verify-play-clock.mjs
+++ b/tools/verify-play-clock.mjs
@@ -1,6 +1,12 @@
 // The phone clock measures visible play, and RESET stays one tap from a game.
+//
+// three layers: the raw clock, the session rule (first move starts it, any
+// gate holds it), and the real store driven with a fake time, so the
+// dialog + hidden-tab overlap is proved on the code the phone runs.
 import { readFileSync } from 'node:fs'
-import { createPlayClock, formatPlayTime } from '../src/lib/ui/play-clock.js'
+import { registerHooks } from 'node:module'
+import { compileModule } from 'svelte/compiler'
+import { createPlayClock, createSessionClock, formatPlayTime } from '../src/lib/ui/play-clock.js'
 
 let now = 1_000
 const clock = createPlayClock(() => now)
@@ -29,9 +35,138 @@ clock.resume()
 now += 1_000
 if (clock.elapsed() !== 43_000 || formatPlayTime(clock.elapsed()) !== '0:43') fail('restored game did not resume honestly')
 
+clock.clear()
+now += 1_000
+if (clock.elapsed() !== 0) fail('a cleared clock still reads time')
+
+// the session rule
+const session = createSessionClock(() => now)
+session.reset()
+now += 30_000
+if (session.elapsed() !== 0) fail('session clock ran before the first move')
+session.begin()
+now += 2_000
+if (session.elapsed() !== 2_000) fail('session clock did not start on the first move')
+session.hold('overlay', true)
+now += 10_000
+if (session.elapsed() !== 2_000) fail('a dialog did not hold the session clock')
+session.hold('hidden', true)
+session.hold('hidden', false)
+session.hold('overlay', false)
+now += 1_000
+if (session.elapsed() !== 3_000) fail('session clock did not resume once every gate cleared')
+session.hold('hidden', true)
+session.hold('overlay', true)
+session.hold('overlay', false)
+now += 10_000
+if (session.elapsed() !== 3_000) fail('closing a dialog resumed a hidden session')
+session.hold('hidden', false)
+session.finish()
+now += 10_000
+if (session.elapsed() !== 3_000) fail('a finished session kept counting')
+session.hold('overlay', true)
+session.hold('overlay', false)
+if (session.elapsed() !== 3_000) fail('closing a dialog restarted a finished session')
+session.reset()
+session.restore(7_000)
+now += 1_000
+if (session.elapsed() !== 8_000) fail('a restored session did not carry its time')
+
+// the store itself: compiled the way the app compiles it, run on a fake clock
+// (the store reads Date.now) and a fake page (document.hidden and localStorage)
+Date.now = () => now
+registerHooks({
+  load(url, context, next) {
+    const loaded = next(url, context)
+    if (!url.endsWith('.svelte.js')) return loaded
+    return { format: 'module', shortCircuit: true, source: compileModule(String(loaded.source), { generate: 'client', filename: url }).js.code }
+  },
+})
+const stored = new Map()
+globalThis.localStorage = {
+  getItem: key => stored.get(key) ?? null,
+  setItem: (key, value) => { stored.set(key, String(value)) },
+  removeItem: key => { stored.delete(key) },
+}
+globalThis.document = { hidden: false, addEventListener() {}, documentElement: { style: { setProperty() {} } } }
+globalThis.addEventListener = () => {}
+globalThis.matchMedia = () => ({ matches: true }) // reduced motion: no confetti canvas to build
+globalThis.window = globalThis
+const { createStore } = await import('../src/lib/ui/store.svelte.js')
+
+// level 1 is two colours, capacity 3, two empties: tube 0 to an empty tube is
+// always a legal first move, and its proof solution is a legal win
+const open = () => { now += 1_000; return createStore() }
+const solveOut = store => { for (const m of store.board.solution) { store.tap(m.from); store.tap(m.to) } }
+
+let store = open()
+store.startLevel(1)
+now += 30_000
+store.setVisible(true) // any tick refreshes the text
+if (store.clock !== '0:00') fail(`store clock ran before the first move: ${store.clock}`)
+store.tap(0); store.tap(2)
+now += 2_000
+store.setVisible(true) // any tick
+if (store.clock !== '0:02') fail(`store clock did not start on the first move: ${store.clock}`)
+
+// the overlap: open help, hide the tab, show the tab, close help
+store.openDialog('howto')
+now += 5_000
+store.setVisible(false)
+now += 5_000
+store.setVisible(true)
+now += 5_000
+store.closeDialog()
+if (store.clock !== '0:02') fail(`dialog + hidden tab leaked into the clock: ${store.clock}`)
+now += 1_000
+store.setVisible(true)
+if (store.clock !== '0:03') fail(`clock did not resume after the last gate cleared: ${store.clock}`)
+
+// closing a dialog over a hidden tab does not resume
+store.setVisible(false)
+store.openDialog('more')
+store.closeDialog()
+now += 10_000
+store.setVisible(true)
+if (store.clock !== '0:03') fail(`closing a dialog resumed a hidden game: ${store.clock}`)
+
+// nor over the levels screen
+store.openLevels()
+store.openDialog('looks')
+store.closeDialog()
+now += 10_000
+store.goGame()
+if (store.clock !== '0:03') fail(`closing a dialog resumed a game behind the levels screen: ${store.clock}`)
+
+// nor a finished board
+store.startLevel(1)
+solveOut(store)
+if (!store.won) fail('the proof solution did not win level 1')
+const finished = store.clock
+store.openDialog('about')
+store.closeDialog()
+now += 10_000
+store.setVisible(true)
+if (store.clock !== finished) fail(`closing a dialog restarted a finished game: ${store.clock} after ${finished}`)
+
+// an untouched board saved and reopened has no time on it; a moved one keeps its time
+store.startLevel(1)
+now += 20_000
+store.setVisible(false)
+store = open()
+if (store.moves !== 0 || store.clock !== '0:00') fail(`an untouched board reloaded with time on it: ${store.clock}`)
+store.tap(0); store.tap(2)
+now += 4_000
+store.setVisible(false)
+store = open()
+now += 60_000
+store.setVisible(true)
+if (store.moves !== 1 || store.clock !== '1:04') fail(`a moved board did not reload with its time: ${store.clock}`)
+
 const page = readFileSync(new URL('../src/routes/+page.svelte', import.meta.url), 'utf8')
 if (!page.includes('<button onclick={() => store.replay()}>RESET</button>')) fail('RESET is not a direct game control')
 if (!page.includes('store.setVisible(!document.hidden)')) fail('visibility is not wired to the play clock')
 if (!page.includes("addEventListener('pagehide', onPageHide)")) fail('page suspension does not save a paused clock')
 
-if (!process.exitCode) console.log('play clock ok: hidden time excluded, restore/resume honest, RESET direct')
+if (!process.exitCode) console.log('play clock ok: starts on the first move, every dialog and hidden tab holds it, restore/resume honest, RESET direct')
+process.exit() // the store's tick interval would keep node up


### PR DESCRIPTION
## what

the level clock now measures play and nothing else.

- it starts on the first move, not when the board opens. an untouched board reads 0:00 however long it sits, and reloads at 0:00.
- every dialog (HOW TO PLAY, ABOUT, LOOKS, MORE, MOVE MY SAVE) holds the clock while it is open.
- closing a dialog never resumes a hidden tab, a finished board, or a game parked behind the levels screen: every gate change re-derives run/pause from the whole set.

`play-clock.js` gains `clear()` on the raw clock and a `createSessionClock` that owns the rule (first move starts it; hidden / overlay / away gates hold it). the store calls `begin()` on a move, `reset()` on a new board, `restore()` for a saved board that has moves, and `hold()` from `openDialog`, `closeDialog`, `openLevels`, `goGame` and `setVisible`. a saved board with no moves on it comes back with no time.

## why

the clock sat next to the "no timers" promise on the MORE sheet while counting idle time before the first tap, under every dialog, and across reloads. #57.

## how verified

`tools/verify-play-clock.mjs` now proves three layers: the raw clock, the session rule, and the real store (compiled with svelte's `compileModule` through a module hook, driven on a fake `Date.now` and a fake page). the store cases: no time before the first move; open help, hide the tab, show the tab, close help, the clock has not advanced; closing a dialog over a hidden tab, over the levels screen, and over a finished board does not resume; an untouched board reloads at 0:00, a moved one keeps its time.

against the shipped store (this branch with `src/lib/ui/store.svelte.js` stashed):

```
FAIL store clock ran before the first move: 0:30
FAIL store clock did not start on the first move: 0:32
FAIL dialog + hidden tab leaked into the clock: 0:37
FAIL clock did not resume after the last gate cleared: 0:43
FAIL closing a dialog resumed a hidden game: 0:43
FAIL closing a dialog resumed a game behind the levels screen: 0:43
FAIL an untouched board reloaded with time on it: 0:20
FAIL a moved board did not reload with its time: 1:24
exit 1
```

patched:

```
play clock ok: starts on the first move, every dialog and hidden tab holds it, restore/resume honest, RESET direct
exit 0
```

`npm run lint:copy`, `npm run verify`, `npm run svelte-check`, `npm run build` all green.

fix #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Ur2KG6AcnCuAaHKfQJUvG
